### PR TITLE
Added missing quote to example code on Custom HTML description

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -117,7 +117,7 @@
           &nbsp;&nbsp;title: <span class="str">'HTML example'</span>,
           &nbsp;&nbsp;html:
           &nbsp;&nbsp;&nbsp;&nbsp;<span class="str">'You can use &lt;b&gt;bold text&lt;/b&gt;, '</span> +
-          &nbsp;&nbsp;&nbsp;&nbsp;<span class="str">&lt;a href="//github.com"&gt;links&lt;/a&gt; '</span> +
+          &nbsp;&nbsp;&nbsp;&nbsp;<span class="str">'&lt;a href="//github.com"&gt;links&lt;/a&gt; '</span> +
           &nbsp;&nbsp;&nbsp;&nbsp;<span class="str">'and other HTML tags'</span>
         });
       </pre>


### PR DESCRIPTION
There was a missing quote on the example code which made the code explode after copy/pasting it