### PR TITLE
dont remove mediaquery if its not existing

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -766,7 +766,9 @@
     // Remove dynamically created media query
     var head = document.getElementsByTagName('head')[0];
     var mediaquery = document.getElementById(mediaqueryId);
-    if (mediaquery) head.removeChild(mediaquery);
+    if (mediaquery) {
+      head.removeChild(mediaquery);
+    }
   }
 
   /*

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -766,7 +766,7 @@
     // Remove dynamically created media query
     var head = document.getElementsByTagName('head')[0];
     var mediaquery = document.getElementById(mediaqueryId);
-    head.removeChild(mediaquery);
+    if (mediaquery) head.removeChild(mediaquery);
   }
 
   /*


### PR DESCRIPTION
@limonte it throws an annoying error everytime someone calls close and its all ready closed. As there is no public method to check the status it should not throw an error