### PR TITLE
Fix css class names

### DIFF
--- a/dist/sweetalert2.css
+++ b/dist/sweetalert2.css
@@ -59,9 +59,9 @@
     cursor: pointer; }
     .sweet-alert button:focus {
       outline: none; }
-    .sweet-alert button.cancel[disabled] {
+    .sweet-alert button.sweet-cancel[disabled] {
       opacity: .4; }
-    .sweet-alert button.confirm[disabled] {
+    .sweet-alert button.sweet-confirm[disabled] {
       border: 4px solid transparent;
       border-color: transparent;
       width: 40px;

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -77,11 +77,11 @@
       outline: none;
     }
 
-    &.cancel[disabled] {
+    &.sweet-cancel[disabled] {
       opacity: .4;
     }
 
-    &.confirm[disabled] {
+    &.sweet-confirm[disabled] {
       border: 4px solid transparent;
       border-color: transparent;
       width: 40px;


### PR DESCRIPTION
Due to renamed class-names in latest release the disabled-styles for the buttons didn't work. #49 #50