### PR TITLE
Fix window.setTimeout error when shimming the window object

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -538,7 +538,7 @@
 
       window.onfocus = function() {
         // When the user has focused away and focused back from the whole window.
-        window.setTimeout(function() {
+        this.setTimeout(function() {
           // Put in a timeout to jump out of the event sequence. Calling focus() in the event
           // sequence confuses things.
           if (lastFocusedButton !== undefined) {


### PR DESCRIPTION
This is related to #97.

I was receiving an "Illegal invocation" error whenever the window was focused. Since the scope of window.onfocus is the global object, we can use `this.setTimeout`. This change fixed the error, and I verified that function passed to setTimeout was still executing.