### PR TITLE
add instructions to show npm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ To install:
 bower install sweetalert2
 ```
 
+Or:
+
+```bash
+npm install sweetalert2
+```
+
 To use:
 
 ```html


### PR DESCRIPTION
Originally I had no idea this package was on npm, even when searching for it (you may want to add more tags, or something). Having npm install instructions are a great way to show that it is there. I almost used the upstream sweetalert despite it having a lacking API. :(