### PR TITLE
Fix, Bower main files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "images"
   ],
   "description": "A replacement for JavaScript's popup boxes, supported fork of sweetalert",
-  "main": ["src/sweetalert2.js", "src/sweetalert2.scss"],
+  "main": ["dist/sweetalert2.min.js", "dist/sweetalert2.min.css"],
   "keywords": [
     "alert",
     "modal"


### PR DESCRIPTION
Grunt did not auto Wiredep all files
Folder changed from .src to .dist

"main": ["dist/sweetalert2.min.js", "dist/sweetalert2.min.css"],