### PR TITLE
Add NPM postinstall script to ignore changes in dist by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "gulp test"
+    "test": "gulp test",
+    "postinstall": "git update-index --assume-unchanged dist/*"
   },
   "bugs": "https://github.com/limonte/sweetalert2/issues",
   "license": "MIT"


### PR DESCRIPTION
This PR is related to @samturrell's comment on https://github.com/limonte/sweetalert2/issues/148

> Might be worth marking them as binary files in a .gitattributes file so that their diff doesn't show up rather than not committing them at all?

As far as I know, it's not possible to ignore changes in files in the index by using `.gitattributes`. 

This PR adds `postinstall` script which runs 
```shell
git update-index --assume-unchanged dist/* 
```
on running `npm install`. 

To see untracked files:
```shell
git update-index --no-assume-unchanged dist/* 
```