### PR TITLE
Add queue() method for chaining modals.

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,6 +274,36 @@ swal({
   }
 })</pre>
     </li>
+
+    <li class="chaining-modals" id="chaining-modals">
+      <div class="ui">
+        <p>Chaining modals example</p>
+        <button>Try me!</button>
+      </div>
+      <pre>
+swal.setDefaults({
+  confirmButtonText: <span class="str">'Next &amp;rarr;'</span>,
+  showCancelButton: <span class="val">true</span>,
+  animation: <span class="val">false</span>
+});
+
+var steps = [
+  {
+    title: <span class="str">'Step 1'</span>,
+    text: <span class="str">'Chaining swal2 modals is easy'</span>
+  },
+  <span class="str">'Step 2'</span>,
+  <span class="str">'Step 3'</span>
+];
+
+swal.queue(steps).then(<span class="func"><i>function</i></span>() {
+  swal({
+    title: <span class="str">'All done!'</span>,
+    confirmButtonText: <span class="str">'Lovely!'</span>,
+    showCancelButton: <span class="val">false</span>
+  });
+})</pre>
+    </li>
   </ul>
 
 
@@ -1161,6 +1191,24 @@ swal({
           html: 'Submitted email: ' + '<strong>' + email + '</strong>'
         });
       }
+    });
+  });
+
+  $('.examples .chaining-modals button').on('click', function() {
+    swal.setDefaults({
+      confirmButtonText: 'Next &rarr;',
+      showCancelButton: true,
+      animation: false
+    });
+
+    var steps = [
+      {title: 'Step 1', text: 'Chaining swal2 modals is easy'},
+      'Step 2',
+      'Step 3'
+    ];
+
+    swal.queue(steps).then(function() {
+      swal({title: 'All done!', confirmButtonText: 'Lovely!', showCancelButton: false});
     });
   });
 

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -718,6 +718,25 @@ function sweetAlert() {
 }
 
 /*
+ * Global function for chaining sweetAlert modals
+ */
+sweetAlert.queue = function(steps) {
+  return new Promise(function(resolve) {
+    (function step(i, callback) {
+      if (i < steps.length) {
+        sweetAlert(steps[i]).then(function(isConfirm) {
+          if (isConfirm) {
+            step(i+1, callback);
+          }
+        });
+      } else {
+        resolve();
+      }
+    })(0);
+  });
+};
+
+/*
  * Global function to close sweetAlert
  */
 sweetAlert.close = sweetAlert.closeModal = function() {

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -5,12 +5,12 @@ import { swalPrefix, swalClasses, iconTypes } from './utils/classes.js';
 import { extend, colorLuminance } from './utils/utils.js';
 import * as dom from './utils/dom.js';
 
-var params = extend({}, defaultParams);
+var modalParams = extend({}, defaultParams);
 
 /*
  * Set type, text and actions on modal
  */
-var setParameters = function() {
+var setParameters = function(params) {
   var i;
   var modal = dom.getModal();
 
@@ -303,9 +303,9 @@ var setParameters = function() {
 /*
  * Animations
  */
-var openModal = function() {
+var openModal = function(animation) {
   var modal = dom.getModal();
-  if (params.animation) {
+  if (animation) {
     dom.fadeIn(dom.getOverlay(), 10);
     dom.addClass(modal, 'show-swal2');
     dom.removeClass(modal, 'hide-swal2');
@@ -335,9 +335,12 @@ function modalDependant() {
     return false;
   }
 
+  var params;
+
   switch (typeof arguments[0]) {
 
     case 'string':
+      params = modalParams;
       params.title = arguments[0];
       params.text  = arguments[1] || '';
       params.type  = arguments[2] || '';
@@ -345,7 +348,7 @@ function modalDependant() {
       break;
 
     case 'object':
-      extend(params, arguments[0]);
+      params = extend(modalParams, arguments[0]);
       params.extraParams = arguments[0].extraParams;
 
       if (params.input === 'email' && params.inputValidator === null) {
@@ -369,9 +372,9 @@ function modalDependant() {
 
   }
 
-  setParameters();
+  setParameters(params);
   fixVerticalPosition();
-  openModal();
+  openModal(params.animation);
 
   // Modal interactions
   var modal = dom.getModal();
@@ -852,14 +855,14 @@ sweetAlert.setDefaults = function(userParams) {
     throw new Error('userParams has to be a object');
   }
 
-  extend(params, userParams);
+  extend(modalParams, userParams);
 };
 
 /**
  * Reset default params for each popup
  */
 sweetAlert.resetDefaults = function() {
-  params = defaultParams;
+  modalParams = defaultParams;
 };
 
 sweetAlert.version = '';

--- a/test/test-runner.html
+++ b/test/test-runner.html
@@ -9,7 +9,7 @@
   <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
   <script src="https://code.jquery.com/qunit/qunit-1.23.1.js"></script>
 
-  <script src="../dist/sweetalert2.min.js"></script>
+  <script src="../dist/sweetalert2.js"></script>
   <script src="https://cdn.jsdelivr.net/es6-promise-polyfill/latest/promise.min.js"></script>
 </head>
 <body>

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,4 +1,3 @@
-
 test('modal shows up', function(assert) {
   var $modal = $('.swal2-modal');
 
@@ -83,4 +82,6 @@ test('set and reset defaults', function(assert) {
   swal('Modal after resetting defaults');
   assert.equal('OK', $('.swal2-confirm').text());
   assert.ok($('.swal2-cancel').is(':hidden'));
+
+  swal.clickCancel();
 });


### PR DESCRIPTION
Related to https://github.com/limonte/sweetalert2/issues/160 and https://github.com/limonte/sweetalert2/issues/125

Usage example:

```js
swal.setDefaults({
  confirmButtonText: 'Next >',
  showCancelButton: true,
  animation: false
});

var steps = [
  {title: 'Step 1', text: 'Chaining swal2 modals is easy'},
  'Step 2',
  'Step 3'
];

swal.queue(steps).then(function() {
  swal.setDefaults
  swal({title: 'All done!', confirmButtonText: 'Lovely!', showCancelButton: false});
});
```

I'll add tests and documentation in next PR.