### PR TITLE
Added onClose and onOpen Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,45 +102,46 @@ Modal Types
 Configuration
 -------------
 
-| Argument              | Default value     | Description |
-| --------------------- | ----------------- | ----------- |
-| `title`               | `null`            | The title of the modal. It can either be added to the object under the key "title" or passed as the first parameter of the function. |
-| `text`                | `null`            | A description for the modal. It can either be added to the object under the key "text" or passed as the second parameter of the function. |
-| `html`                | `null`            | A HTML description for the modal. If `text` and `html` parameters are provided in the same time, "text" will be used. |
-| `type `               | `null`            | The type of the modal. SweetAlert2 comes with [5 built-in types](#modal-types) which will show a corresponding icon animation: `warning`, `error`, `success`, `info` and `question`. It can either be put in the array under the key `type` or passed as the third parameter of the function. |
-| `customClass`         | `null`            | A custom CSS class for the modal. |
-| `animation`           | `true`            | If set to `false`, modal CSS animation will be disabled. |
-| `allowOutsideClick`   | `true`            | If set to `false`, the user can't dismiss the modal by clicking outside it. |
-| `allowEscapeKey`      | `true`            | If set to `false`, the user can't dismiss the modal by pressing the Escape key. |
-| `showConfirmButton`   | `true`            | If set to `false`, a "Confirm"-button will not be shown. It can be useful when you're using `html` parameter for custom HTML description. |
-| `showCancelButton`    | `false`           | If set to `true`, a "Cancel"-button will be shown, which the user can click on to dismiss the modal. |
-| `confirmButtonText`   | `"OK"`            | Use this to change the text on the "Confirm"-button. |
-| `cancelButtonText`    | `"Cancel"`        | Use this to change the text on the "Cancel"-button. |
-| `confirmButtonColor`  | `"#3085d6"`       | Use this to change the background color of the "Confirm"-button (must be a HEX value). |
-| `cancelButtonColor`   | `"#aaa"`          | Use this to change the background color of the "Cancel"-button (must be a HEX value). |
-| `confirmButtonClass`  | `null`            | A custom CSS class for the "Confirm"-button. |
-| `cancelButtonClass`   | `null`            | A custom CSS class for the "Cancel"-button. |
-| `buttonsStyling`      | `true`            | Apply default swal2 styling to buttons. If you want to use your own classes (e.g. Bootstrap classes) set this parameter to `false`. |
-| `reverseButtons`      | `false`           | Set to `true` if you want to invert default buttons positions. |
-| `showCloseButton`     | `false`           | Set to `true` to show close button in top right corner of the modal. |
-| `showLoaderOnConfirm` | `false`           | Set to `true` to disable buttons and show that something is loading. Useful for AJAX requests. |
-| `preConfirm`          | `null`            | Function to execute before confirm, should return Promise, see <a href="https://limonte.github.io/sweetalert2/#ajax-request">usage example</a>. |
-| `imageUrl`            | `null`            | Add a customized icon for the modal. Should contain a string with the path or URL to the image. |
-| `imageWidth`          | `null`            | If imageUrl is set, you can specify imageWidth to describes image width in px. |
-| `imageHeight`         | `null`            | Custom image height in px. |
-| `imageClass`          | `null`            | A custom CSS class for the customized icon. |
-| `timer`               | `null`            | Auto close timer of the modal. Set in ms (milliseconds). |
-| `width`               | `500`             | Modal window width, including paddings (`box-sizing: border-box`). |
-| `padding`             | `20`              | Modal window padding. |
-| `background`          | `"#fff"`          | Modal window background (CSS `background` property). |
-| `input`               | `null`            | Input field type, can be `"text"`, `"email"`, `"password"`, `"textarea"`, `"select"`, `"radio"`, `"checkbox"` and `"file"`. |
-| `inputPlaceholder`    | `""`              | Input field placeholder. |
-| `inputValue`          | `""`              | Input field initial value. |
-| `inputOptions`        | `{}` or `Promise` | If `input` parameter is set to `"select"` or `"radio"`, you can provide options. Object keys will represent options values, object values will represent options text values. |
-| `inputAutoTrim`       | `true`            | Automatically remove whitespaces from both ends of a result string. Set this parameter to `false` to disable auto-trimming. |
-| `inputValidator`      | `null`            | Validator for input field, should return Promise, see <a href="https://limonte.github.io/sweetalert2/#select-box">usage example</a>. |
-| `inputClass`          | `null`            | A custom CSS class for the input field. |
-
+| Argument              | Default value        | Description |
+| --------------------- | -------------------- | ----------- |
+| `title`               | `null`               | The title of the modal. It can either be added to the object under the key "title" or passed as the first parameter of the function. |
+| `text`                | `null`               | A description for the modal. It can either be added to the object under the key "text" or passed as the second parameter of the function. |
+| `html`                | `null`               | A HTML description for the modal. If `text` and `html` parameters are provided in the same time, "text" will be used. |
+| `type `               | `null`               | The type of the modal. SweetAlert2 comes with [5 built-in types](#modal-types) which will show a corresponding icon animation: `warning`, `error`, `success`, `info` and `question`. It can either be put in the array under the key `type` or passed as the third parameter of the function. |
+| `customClass`         | `null`               | A custom CSS class for the modal. |
+| `animation`           | `true`               | If set to `false`, modal CSS animation will be disabled. |
+| `allowOutsideClick`   | `true`               | If set to `false`, the user can't dismiss the modal by clicking outside it. |
+| `allowEscapeKey`      | `true`               | If set to `false`, the user can't dismiss the modal by pressing the Escape key. |
+| `showConfirmButton`   | `true`               | If set to `false`, a "Confirm"-button will not be shown. It can be useful when you're using `html` parameter for custom HTML description. |
+| `showCancelButton`    | `false`              | If set to `true`, a "Cancel"-button will be shown, which the user can click on to dismiss the modal. |
+| `confirmButtonText`   | `"OK"`               | Use this to change the text on the "Confirm"-button. |
+| `cancelButtonText`    | `"Cancel"`           | Use this to change the text on the "Cancel"-button. |
+| `confirmButtonColor`  | `"#3085d6"`          | Use this to change the background color of the "Confirm"-button (must be a HEX value). |
+| `cancelButtonColor`   | `"#aaa"`             | Use this to change the background color of the "Cancel"-button (must be a HEX value). |
+| `confirmButtonClass`  | `null`               | A custom CSS class for the "Confirm"-button. |
+| `cancelButtonClass`   | `null`               | A custom CSS class for the "Cancel"-button. |
+| `buttonsStyling`      | `true`               | Apply default swal2 styling to buttons. If you want to use your own classes (e.g. Bootstrap classes) set this parameter to `false`. |
+| `reverseButtons`      | `false`              | Set to `true` if you want to invert default buttons positions. |
+| `showCloseButton`     | `false`              | Set to `true` to show close button in top right corner of the modal. |
+| `showLoaderOnConfirm` | `false`              | Set to `true` to disable buttons and show that something is loading. Useful for AJAX requests. |
+| `preConfirm`          | `null`               | Function to execute before confirm, should return Promise, see <a href="https://limonte.github.io/sweetalert2/#ajax-request">usage example</a>. |
+| `imageUrl`            | `null`               | Add a customized icon for the modal. Should contain a string with the path or URL to the image. |
+| `imageWidth`          | `null`               | If imageUrl is set, you can specify imageWidth to describes image width in px. |
+| `imageHeight`         | `null`               | Custom image height in px. |
+| `imageClass`          | `null`               | A custom CSS class for the customized icon. |
+| `timer`               | `null`               | Auto close timer of the modal. Set in ms (milliseconds). |
+| `width`               | `500`                | Modal window width, including paddings (`box-sizing: border-box`). |
+| `padding`             | `20`                 | Modal window padding. |
+| `background`          | `"#fff"`             | Modal window background (CSS `background` property). |
+| `input`               | `null`               | Input field type, can be `"text"`, `"email"`, `"password"`, `"textarea"`, `"select"`, `"radio"`, `"checkbox"` and `"file"`. |
+| `inputPlaceholder`    | `""`                 | Input field placeholder. |
+| `inputValue`          | `""`                 | Input field initial value. |
+| `inputOptions`        | `{}` or `Promise`    | If `input` parameter is set to `"select"` or `"radio"`, you can provide options. Object keys will represent options values, object values will represent options text values. |
+| `inputAutoTrim`       | `true`               | Automatically remove whitespaces from both ends of a result string. Set this parameter to `false` to disable auto-trimming. |
+| `inputValidator`      | `null`               | Validator for input field, should return Promise, see <a href="https://limonte.github.io/sweetalert2/#select-box">usage example</a>. |
+| `inputClass`          | `null`               | A custom CSS class for the input field. |
+| `onOpen`              | `null` or `Function` | Function to run when modal opens, provides modal dom element as first param
+| `onClose`             | `null` or `Function` | Function to run when modal closes, provides modal dom element as first param
 You can redefine default params by using `swal.setDefaults(customParams)` where `customParams` is an object.
 
 

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -198,7 +198,7 @@ var setParameters = function(params) {
 /*
  * Animations
  */
-var openModal = function(animation) {
+var openModal = function(animation, onComplete) {
   var modal = dom.getModal();
   if (animation) {
     dom.fadeIn(dom.getOverlay(), 10);
@@ -208,10 +208,11 @@ var openModal = function(animation) {
     dom.show(dom.getOverlay());
   }
   dom.show(modal);
-
   dom.states.previousActiveElement = document.activeElement;
-
   dom.addClass(modal, 'visible');
+  if (onComplete !== null && typeof onComplete === 'function') {
+    onComplete.call(this, modal);
+  }
 };
 
 /*
@@ -274,12 +275,13 @@ function modalDependant() {
     // Close on timer
     if (params.timer) {
       modal.timeout = setTimeout(function() {
-        sweetAlert.closeModal();
+        sweetAlert.closeModal(params.onClose);
         reject('timer');
       }, params.timer);
     }
 
-    // input/select autofocus
+
+      // input/select autofocus
     var getInput = function() {
       switch (params.input) {
         case 'select':
@@ -326,8 +328,8 @@ function modalDependant() {
       if (params.preConfirm) {
         params.preConfirm(value, params.extraParams).then(
           function(preConfirmValue) {
+            sweetAlert.closeModal(params.onClose);
             resolve(preConfirmValue || value);
-            sweetAlert.closeModal();
           },
           function(error) {
             sweetAlert.hideLoading();
@@ -337,8 +339,8 @@ function modalDependant() {
           }
         );
       } else {
+        sweetAlert.closeModal(params.onClose);
         resolve(value);
-        sweetAlert.closeModal();
       }
     };
 
@@ -411,8 +413,7 @@ function modalDependant() {
 
           // Clicked 'cancel'
           } else if (targetedCancel && modalIsVisible) {
-
-            sweetAlert.closeModal();
+            sweetAlert.closeModal(params.onClose);
             reject('cancel');
           }
 
@@ -437,10 +438,10 @@ function modalDependant() {
       var target = e.target || e.srcElement;
 
       if (dom.hasClass(target, swalClasses.close)) {
-        sweetAlert.closeModal();
+        sweetAlert.closeModal(params.onClose);
         reject('close');
       } else if (target === dom.getOverlay() && params.allowOutsideClick) {
-        sweetAlert.closeModal();
+        sweetAlert.closeModal(params.onClose);
         reject('overlay');
       }
     };
@@ -525,7 +526,7 @@ function modalDependant() {
             dom.fireClick($confirmButton, e);
           }
         } else if (keyCode === 27 && params.allowEscapeKey === true) {
-          sweetAlert.closeModal();
+          sweetAlert.closeModal(params.onClose);
           reject('esc');
         }
       }
@@ -750,7 +751,7 @@ function modalDependant() {
     }
 
     fixVerticalPosition();
-    openModal(params.animation);
+    openModal(params.animation, params.onOpen);
 
     // Focus the first element (input or button)
     setFocus(-1, 1);
@@ -797,7 +798,7 @@ sweetAlert.queue = function(steps) {
 /*
  * Global function to close sweetAlert
  */
-sweetAlert.close = sweetAlert.closeModal = function() {
+sweetAlert.close = sweetAlert.closeModal = function(onComplete) {
   var modal = dom.getModal();
   dom.removeClass(modal, 'show-swal2');
   dom.addClass(modal, 'hide-swal2');
@@ -829,6 +830,9 @@ sweetAlert.close = sweetAlert.closeModal = function() {
   } else {
     dom._hide(modal);
     dom._hide(dom.getOverlay());
+  }
+  if (onComplete !== null && typeof onComplete === 'function') {
+    onComplete.call(this, modal);
   }
 };
 

--- a/src/utils/default.js
+++ b/src/utils/default.js
@@ -36,7 +36,9 @@ export var defaultParams = {
   inputAutoTrim: true,
   inputClass: null,
   inputAttributes: {},
-  inputValidator: null
+  inputValidator: null,
+  onOpen: null,
+  onClose: null,
 };
 
 export var sweetHTML = '<div class="' + swalClasses.overlay + '" tabIndex="-1"></div>' +


### PR DESCRIPTION
Needed access to the dom provided by the modal when it opens, there aren't currently any events that provide closing or opening tie-ins. This commit adds those in as well as updates the documentation.