### PR TITLE
fix SweetAlert2 example

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 
     <h5>Code:</h5>
     <pre>
-sweetAlert()
+sweetAlert(
   <span class="str">'Oops...'</span>,
   <span class="str">'Something went wrong!'</span>,
   <span class="str">'error'</span>


### PR DESCRIPTION
originally the SweetAlert2 example used to show `sweetAlert()...code...)` but after this PR it is corrected to `sweetAlert(...code...)`