### PR TITLE
Patch resetPrevState in dom.js to be compatible with IE11 and SVG

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -222,7 +222,7 @@ export var animationEndEvent = (function() {
 export var resetPrevState = function() {
   var modal = getModal();
   window.onkeydown = states.previousWindowKeyDown;
-  if (states.previousActiveElement) {
+  if (states.previousActiveElement && states.previousActiveElement.focus) {
     states.previousActiveElement.focus();
   }
   clearTimeout(modal.timeout);


### PR DESCRIPTION
I found a bug yesterday when i tried i site i am building on IE11 for the first time (because my employer is behind the times). SVG elements in IE11 don't support focus so it breaks when you dismiss alerts triggered from them.