### PR TITLE
Minor gulp fixes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ var utils = require('./config/utils.js');
 gulp.task('compress', ['lint', 'commonjs', 'dev', 'production']);
 
 gulp.task('lint', function() {
-  return gulp.src(['src/*.js', 'src/utils/*.js', 'test/*.js'])
+  return gulp.src(['src/**/*.js', 'test/*.js'])
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError());
@@ -67,12 +67,8 @@ gulp.task('default', ['compress', 'sass']);
 
 gulp.task('watch', function() {
   gulp.watch([
-    'src/sweetalert2.js',
-    'src/utils/classes.js',
-    'src/utils/default.js',
-    'src/utils/dom.js',
-    'src/utils/utils.js',
-    'src/utils/classes.js'
+    'src/**/*.js',
+    'test/*.js',
   ], ['compress']);
 
   gulp.watch([

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,10 @@ gulp.task('dev', function() {
 
 gulp.task('test', function() {
   return gulp.src('./test/test-runner.html')
-    .pipe(qunit());
+    .pipe(qunit())
+    .on('error', function(err){ // avoid the ugly error message on failing
+      this.emit('end');
+    });
 });
 
 gulp.task('production', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,6 +36,9 @@ gulp.task('test', function() {
   return gulp.src('./test/test-runner.html')
     .pipe(qunit())
     .on('error', function(err){ // avoid the ugly error message on failing
+      if (process.env.CI) { // but still fail if we're running in a CI
+        throw err;
+      }
       this.emit('end');
     });
 });
@@ -69,10 +72,10 @@ gulp.task('watch', function() {
   gulp.watch([
     'src/**/*.js',
     'test/*.js',
-  ], ['compress']);
+  ], ['compress', 'test']);
 
   gulp.watch([
     'src/sweetalert2.scss',
     'example/example.scss'
-  ], ['sass']);
+  ], ['sass', 'test']);
 });


### PR DESCRIPTION
Tests are now run as part of the `gulp watch` task, so we don't have to create a pull request/run it manually before seeing failing tests.  
Made the `gulp watch` task also watch test changes.  
Failing tests no longer throws an exception (unless it's running in a CI, as checked by checking [env variables](https://docs.travis-ci.com/user/environment-variables#Default-Environment-Variables)), nor logs a massive useless error:

```
[01:49:58] Error in plugin 'gulp-qunit'
Message:
    Command failed: C:\Users\-\Desktop\GitHub\sweetalert2\node_modules\gulp-
qunit\node_modules\phantomjs-prebuilt\lib\phantom\bin\phantomjs.exe C:\Users\-\Desktop\GitHub\sweetalert2\node_modules\gulp-qunit\node_modules\qunit-phantom
js-runner\runner.js file:///C:/Users/-/Desktop/GitHub/sweetalert2/test/test-
runner.html

Details:
    killed: false
    code: 1
    signal: null
    cmd: C:\Users\-\Desktop\GitHub\sweetalert2\node_modules\gulp-qunit\node_
modules\phantomjs-prebuilt\lib\phantom\bin\phantomjs.exe C:\Users\-\Desktop\
GitHub\sweetalert2\node_modules\gulp-qunit\node_modules\qunit-phantomjs-runner\r
unner.js file:///C:/Users/-/Desktop/GitHub/sweetalert2/test/test-runner.html
```

It will still log info on failing tests, but not break the running task/watchers.