### PR TITLE
Add check for null modal in fixVerticalPosition

### DIFF
--- a/dist/sweetalert2.js
+++ b/dist/sweetalert2.js
@@ -626,8 +626,10 @@
    */
   var fixVerticalPosition = function() {
     var modal = getModal();
-
-    modal.style.marginTop = getTopMargin(modal);
+    
+    if (modal !== null) {
+      modal.style.marginTop = getTopMargin(modal);
+    }
   };
 
   function modalDependant() {


### PR DESCRIPTION
Hello!

In this PR we're introducing a simple check in `fixVerticalPosition` in order to fix an unhandled error :hammer: 

![sweetalert2-unhandled-error](https://cloud.githubusercontent.com/assets/761656/17735086/251b30f0-6489-11e6-9581-80cd048423b8.gif)

I'm doing a lot of window resizing when coding responsive UIs and this error is driving me & our project errorception.com nuts :D

I'm open for feedback and suggestions how best to approach this. Thank you for your attention! 

