### PR TITLE
added null check to fixVerticalPosition

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -230,8 +230,12 @@ var openModal = function(animation, onComplete) {
  */
 var fixVerticalPosition = function() {
   var modal = dom.getModal();
+  if (!modal){ 
+    return;
+  }
 
   modal.style.marginTop = dom.getTopMargin(modal);
+
 };
 
 function modalDependant() {


### PR DESCRIPTION
Added a null check to fixVerticalPosition which  is being called during window resizing event.

This causes a large number of errors when no modal is actually open.

Source of event: 
window.addEventListener('resize', fixVerticalPosition, false);

