### PR TITLE
Make work in hot-module-replacement environments

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -894,6 +894,15 @@ function modalDependant() {
 
     // fix scroll
     sweetContainer.scrollTop = 0;
+
+    // Observe changes inside the modal and adjust height
+    if (typeof MutationObserver !== 'undefined') {
+      var mutationsHandler = dom.debounce(function() {
+        sweetAlert.recalculateHeight();
+      }, 50);
+      var swal2Observer = new MutationObserver(mutationsHandler);
+      swal2Observer.observe(modal, {childList: true, characterData: true, subtree: true});
+    }
   });
 }
 
@@ -1095,15 +1104,6 @@ sweetAlert.init = function() {
   textarea.oninput = function() {
     sweetAlert.resetValidationError();
   };
-
-  // Observe changes inside the modal and adjust height
-  if (typeof MutationObserver !== 'undefined') {
-    var mutationsHandler = dom.debounce(function() {
-      sweetAlert.recalculateHeight();
-    }, 50);
-    var swal2Observer = new MutationObserver(mutationsHandler);
-    swal2Observer.observe(modal, {childList: true, characterData: true, subtree: true});
-  }
 
   return modal;
 };

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -7,6 +7,7 @@ import * as dom from './utils/dom.js';
 
 var modalParams = extend({}, defaultParams);
 var queue = [];
+var swal2Observer;
 
 /*
  * Set type, text and actions on modal
@@ -896,11 +897,11 @@ function modalDependant() {
     sweetContainer.scrollTop = 0;
 
     // Observe changes inside the modal and adjust height
-    if (typeof MutationObserver !== 'undefined') {
+    if (typeof MutationObserver !== 'undefined' && !swal2Observer) {
       var mutationsHandler = dom.debounce(function() {
         sweetAlert.recalculateHeight();
       }, 50);
-      var swal2Observer = new MutationObserver(mutationsHandler);
+      swal2Observer = new MutationObserver(mutationsHandler);
       swal2Observer.observe(modal, {childList: true, characterData: true, subtree: true});
     }
   });

--- a/src/utils/default.js
+++ b/src/utils/default.js
@@ -80,6 +80,14 @@ var sweetHTML = '<div class="' + swalClasses.modal + '" style="display: none" ta
     '<span class="' + swalClasses.close + '">&times;</span>' +
   '</div>';
 
-export var sweetContainer = document.createElement('div');
-sweetContainer.className = swalClasses.container;
-sweetContainer.innerHTML = sweetHTML;
+export var sweetContainer;
+
+var existingSweetContainers = document.getElementsByClassName(swalClasses.container);
+
+if (existingSweetContainers.length) {
+  sweetContainer = existingSweetContainers[0];
+} else {
+  sweetContainer = document.createElement('div');
+  sweetContainer.className = swalClasses.container;
+  sweetContainer.innerHTML = sweetHTML;
+}


### PR DESCRIPTION
When using hot module replacement (in my case with Knockout + Webpack) where code and its deps are re-evaluated, swal creates new containers and acts upon those, but they are never inserted into the DOM.