### PR TITLE
Proper module exporting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
       'vars': 'local',
       'args': 'after-used'
     }],
+    'no-undef': 2,                   // http://eslint.org/docs/rules/no-undef
     'no-use-before-define': 0,       // http://eslint.org/docs/rules/no-use-before-define
     /**
      * Possible errors

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ To use:
 <link rel="stylesheet" type="text/css" href="bower_components/sweetalert2/dist/sweetalert2.min.css">
 ```
 
+Or:
+
+```javascript
+// ES6 Modules
+import { default as swal } from 'sweetalert2'
+
+// CommonJS
+const swal = require('sweetalert2')
+```
+
 
 Examples
 --------

--- a/config/utils.js
+++ b/config/utils.js
@@ -36,6 +36,7 @@ var write = function(dest, code) {
 };
 
 var packageRollup = function(options) {
+  const moduleId = classify(pack.name);
   return rollup({
     entry: 'src/sweetalert2.js'
   })
@@ -43,7 +44,8 @@ var packageRollup = function(options) {
     var code = bundle.generate({
       format: options.format,
       banner: banner,
-      moduleName: classify(pack.name)
+      moduleName: classify(pack.name),
+      footer: `if (window.${moduleId}) window.sweetAlert = window.swal = window.${moduleId};`
     }).code.replace(/sweetAlert\.version = '(.*)'/, "sweetAlert.version = '" + pack.version + "'");
 
     if (options.minify) {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://limonte.github.io/sweetalert2/",
   "description": "A replacement for JavaScript's popup boxes, supported fork of sweetalert",
   "main": "dist/sweetalert2.js",
+  "jsnext:main": "src/sweetalert2.js",
   "dependencies": {
     "es6-promise": "latest"
   },

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -1064,8 +1064,6 @@ sweetAlert.resetDefaults = function() {
 
 sweetAlert.version = '';
 
-window.sweetAlert = window.swal = sweetAlert;
-
 if (typeof Promise === 'function') {
   Promise.prototype.done = Promise.prototype.done || function() {
     return this.catch(function() {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,3 +1,4 @@
+import { default as sweetAlert } from '../sweetalert2.js';
 import { swalPrefix, swalClasses } from './classes.js';
 import { sweetContainer } from './default.js';
 


### PR DESCRIPTION
This could be breaking — but also extremely easy to remedy on the user side — so I'm not sure if you'll want it or not, but for trying to use both sweetalert and sweetalert2 (we have a huge legacy codebase) it's crucial.

I've tweaked the readme's usage section and added a `jsnext:main` to the `package.json` as well.

🍻 