### PR TITLE
Fix build by changing node version from 'stable' to 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - stable
+  - 6
 
 cache:
   bundler: true


### PR DESCRIPTION
This PR is fixing broken build https://travis-ci.org/limonte/sweetalert2/builds/171247091 because current node js stable is 7 and node-sass doesn't support it yet.