### PR TITLE
Remove Promise.prototype.done

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -1087,15 +1087,4 @@ sweetAlert.noop = () => { }
 
 sweetAlert.version = ''
 
-if (typeof Promise === 'function') {
-  Promise.prototype.done = Promise.prototype.done || function () { // eslint-disable-line
-    return this.catch(function () {
-      // Catch promise rejections silently.
-      // https://github.com/limonte/sweetalert2/issues/177
-    })
-  }
-} else {
-  console.warn('SweetAlert2: Please inlude Promise polyfill BEFORE including sweetalert2.js if IE10+ support needed.')
-}
-
 export default sweetAlert

--- a/test/tests.js
+++ b/test/tests.js
@@ -58,7 +58,7 @@ test('cancel button', function (assert) {
       assert.equal(dismiss, 'cancel')
       done()
     }
-  ).done()
+  ).catch(swal.noop)
 
   swal.clickCancel()
 })
@@ -142,7 +142,7 @@ test('set and reset defaults', function (assert) {
   assert.ok($('.swal2-cancel').is(':visible'))
 
   swal.resetDefaults()
-  swal('Modal after resetting defaults').done()
+  swal('Modal after resetting defaults').catch(swal.noop)
   assert.equal($('.swal2-confirm').text(), 'OK')
   assert.ok($('.swal2-cancel').is(':hidden'))
 
@@ -244,7 +244,7 @@ test('queue', function (assert) {
       swal.clickConfirm()
 
       // test queue is cancelled on first step, other steps shouldn't be shown
-      swal.queue(steps).done()
+      swal.queue(steps).catch(swal.noop)
       swal.clickCancel()
       assert.notOk(swal.isVisible())
       done()


### PR DESCRIPTION
Related to #324

`.done()` will be removed in next major release. Please use `.catch(swal.noop)` instead.