### PR TITLE
Gulp fixes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,13 @@
 {
   "presets": [
-    "es2015-rollup"
+  	[
+	    "es2015",
+	    {
+	    	"modules": false
+	    }
+	]
   ],
   "plugins": [
-    "transform-object-assign"
+  	"external-helpers"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,14 @@
 {
   "presets": [
-  	[
-	    "es2015",
-	    {
-	    	"modules": false
-	    }
-	]
+    [
+      "es2015",
+      {
+        "modules": false
+      }
+  ]
   ],
   "plugins": [
-  	"external-helpers"
+    "external-helpers",
+    "transform-object-assign"
   ]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,13 +34,17 @@ gulp.task('dev', () => {
   })
 })
 
-var gutil = require('gulp-util')
 gulp.task('test', () => {
   return gulp.src('./test/test-runner.html')
     .pipe(qunit())
     .on('error', function (err) { // avoid the ugly error message on failing
       if (process.env.CI) { // but still fail if we're running in a CI
         throw err
+      } else if (err.name !== "Error" || err.code !== 1) {
+        // rather crude filter
+        // this blocks the 'Command failed' error every time gulp-qunit fails
+        // logs all other errors without breaking the watcher
+        console.error(err.toString())
       }
       this.emit('end')
     })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,10 +34,11 @@ gulp.task('dev', () => {
   })
 })
 
+var gutil = require('gulp-util')
 gulp.task('test', () => {
   return gulp.src('./test/test-runner.html')
     .pipe(qunit())
-    .on('error', (err) => { // avoid the ugly error message on failing
+    .on('error', function (err) { // avoid the ugly error message on failing
       if (process.env.CI) { // but still fail if we're running in a CI
         throw err
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "babel-plugin-external-helpers": "latest",
     "babel-preset-es2015": "latest",
+    "babel-plugin-transform-object-assign": "latest",
     "gulp": "latest",
     "gulp-autoprefixer": "latest",
     "gulp-clean-css": "latest",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "es6-promise": "latest"
   },
   "devDependencies": {
-    "babel-preset-es2015-rollup": "latest",
-    "babel-plugin-transform-object-assign": "latest",
+    "babel-plugin-external-helpers": "latest",
+    "babel-preset-es2015": "latest",
     "gulp": "latest",
     "gulp-autoprefixer": "latest",
     "gulp-clean-css": "latest",

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -291,6 +291,7 @@ const undoIOSfix = () => {
   if (dom.hasClass(document.body, swalClasses.iosfix)) {
     const offset = parseInt(document.body.style.top, 10)
     dom.removeClass(document.body, swalClasses.iosfix)
+    document.body.style.top = ''
     document.body.scrollTop = (offset * -1)
   }
 }


### PR DESCRIPTION
Various gulp fixes:
- Bug in which `this.emit` would throw, since the arrow function did not bind `this`
- The watcher now throws every error that isn't the basic "Command failed" error that happens when `gulp-qunit` fails - makes for easier debugging
- The babel preset has been updated to go with [the new rollup configuration](https://github.com/rollup/rollup-plugin-babel#configuring-babel) (fixes #357)