### PR TITLE
Specify fuzzy version dependency for es6-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "dist/sweetalert2.js",
   "jsnext:main": "src/sweetalert2.js",
   "dependencies": {
-    "es6-promise": "latest"
+    "es6-promise": "^4.0.5"
   },
   "devDependencies": {
     "babel-plugin-external-helpers": "latest",


### PR DESCRIPTION
Having a dependency on `"latest"` means that whenever someone tries to shrinkwrap, it will fail if they don't have the latest version of `es6-promise` installed. This means that users of your package will have `npm shrinkwrap` break non-deterministically when the `es6-promise` package is updated on npm. It also means that we are unable to install other unrelated packages until we update `es6-promise`.