### PR TITLE
Set a normal line-height on the modal's title (#396)

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -90,9 +90,8 @@ body {
     font-weight: 600;
     text-transform: none;
     position: relative;
-    margin: 0;
+    margin: 0 0 .4em;
     padding: 0;
-    line-height: 60px;
     display: block;
   }
 


### PR DESCRIPTION
Follow-up on #396.

Here's my proposal: delete our custom `line-height` entirely to let the browser apply its own default line-spacing, that is meant to be readable. The default value for `line-height` in CSS is `"normal"` and is about ~1.2 em.

Plus, we add a little bottom margin to the title to compensate the lost of the line spacing.

Before :
![selection_185](https://cloud.githubusercontent.com/assets/1343250/21734044/b176d7aa-d461-11e6-9762-84cb07e81034.png)

After :
![selection_184](https://cloud.githubusercontent.com/assets/1343250/21734054/bec10142-d461-11e6-873d-3c3811a0a51e.png)