### PR TITLE
Add methods for quick access to title, content, input, image and buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-SweetAlert2 
+SweetAlert2
 -----------
 
 [![Build Status](https://travis-ci.org/limonte/sweetalert2.svg?branch=master)](https://travis-ci.org/limonte/sweetalert2) [![Downloads](https://img.shields.io/npm/dt/sweetalert2.svg)](https://www.npmjs.com/package/sweetalert2) [![Version](https://img.shields.io/npm/v/sweetalert2.svg)](https://www.npmjs.com/package/sweetalert2) [![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sweetalert2/Lobby)
@@ -195,6 +195,11 @@ Methods
 | `swal.setDefaults({Object})`                    | If you end up using a lot of the same settings when calling SweetAlert2, you can use setDefaults at the start of your program to set them once and for all! |
 | `swal.resetDefaults()`                          | Resets settings to their default value. |
 | `swal.close()` or `swal.closeModal()`           | Close the currently open SweetAlert2 modal programmatically. |
+| `swal.getTitle()`                               | Get the modal title. |
+| `swal.getContent()`                             | Get the modal content. |
+| `swal.getImage()`                               | Get the image. |
+| `swal.getConfirmButton()`                       | Get the "Confirm" button. |
+| `swal.getCancelButton()`                        | Get the "Cancel" button. |
 | `swal.enableButtons()`                          | Enable "Confirm" and "Cancel" buttons. |
 | `swal.disableButtons()`                         | Disable "Confirm" and "Cancel" buttons. |
 | `swal.enableConfirmButton()`                    | Enable the "Confirm"-button only. |
@@ -205,7 +210,7 @@ Methods
 | `swal.clickCancel()`                            | Click the "Cancel"-button programmatically. |
 | `swal.showValidationError(error)`               | Show validation error message. |
 | `swal.resetValidationError()`                   | Hide validation error message. |
-| `swal.getInput()`                               | Get input node or array of nodes (radios), this method works with `input` parameter. |
+| `swal.getInput()`                               | Get the input DOM node, this method works with `input` parameter. |
 | `swal.disableInput()`                           | Disable input. A disabled input element is unusable and un-clickable. |
 | `swal.enableInput()`                            | Enable input. |
 | `swal.queue([Array])`                           | Provide array of SweetAlert2 parameters to show multiple modals, one modal after another or a function that returns alert parameters given modal number. See [usage example](https://limonte.github.io/sweetalert2/#chaining-modals).  |

--- a/README.md
+++ b/README.md
@@ -205,8 +205,9 @@ Methods
 | `swal.clickCancel()`                            | Click the "Cancel"-button programmatically. |
 | `swal.showValidationError(error)`               | Show validation error message. |
 | `swal.resetValidationError()`                   | Hide validation error message. |
-| `swal.enableInput()`                            | Enable input, this method works with `input` parameter. |
-| `swal.disableInput()`                           | Disable input. |
+| `swal.getInput()`                               | Get input node or array of nodes (radios), this method works with `input` parameter. |
+| `swal.disableInput()`                           | Disable input. A disabled input element is unusable and un-clickable. |
+| `swal.enableInput()`                            | Enable input. |
 | `swal.queue([Array])`                           | Provide array of SweetAlert2 parameters to show multiple modals, one modal after another or a function that returns alert parameters given modal number. See [usage example](https://limonte.github.io/sweetalert2/#chaining-modals).  |
 | `swal.getQueueStep()`                           | Get the index of current modal in queue. When there's no active queue, `null` will be returned. |
 | `swal.insertQueueStep()`                        | Insert a modal to queue, you can specify modal positioning with second parameter. By default a modal will be added to the end of a queue. |

--- a/index.html
+++ b/index.html
@@ -1059,12 +1059,16 @@ swal({
         <td>Hide validation error message.</td>
       </tr>
       <tr>
-        <td><i>swal.enableInput()</i></td>
-        <td>Enable input, this method works with <a href="#input-parameter">input parameter</a>.</td>
+        <td><i>swal.getInput()</i></td>
+        <td>Get input node or array of nodes (radios), this method works with <a href="#input-parameter">input parameter</a>.</td>
       </tr>
       <tr>
         <td><i>swal.disableInput()</i></td>
-        <td>Disable input.</td>
+        <td>Disable input. A disabled input element is unusable and un-clickable.</td>
+      </tr>
+      <tr>
+        <td><i>swal.enableInput()</i></td>
+        <td>Enable input.</td>
       </tr>
       <tr>
         <td><i>swal.queue([Array])</i></td>

--- a/index.html
+++ b/index.html
@@ -559,7 +559,7 @@ swal({
         <td><i>null</i></td>
         <td>Function to execute before confirm, should return Promise, see <a href="#ajax-request">usage example</a>.</td>
       </tr>
-      <tr>
+      <tr id="image">
         <td><b>imageUrl</b></td>
         <td><i>null</i></td>
         <td>Add a customized icon for the modal. Should contain a string with the path or URL to the image.</td>
@@ -1023,6 +1023,26 @@ swal({
         <td>Enable "Confirm" and "Cancel" buttons.</td>
       </tr>
       <tr>
+        <td><i>swal.getTitle()</i></td>
+        <td>Get the modal title.</td>
+      </tr>
+      <tr>
+        <td><i>swal.getContent()</i></td>
+        <td>Get the modal content.</td>
+      </tr>
+      <tr>
+        <td><i>swal.getImage()</i></td>
+        <td>Get the <a href="#image">image</a>.</td>
+      </tr>
+      <tr>
+        <td><i>swal.getConfirmButton()</i></td>
+        <td>Get the "Confirm" button.</td>
+      </tr>
+      <tr>
+        <td><i>swal.getCancelButton()</i></td>
+        <td>Get the "Cancel" button.</td>
+      </tr>
+      <tr>
         <td><i>swal.disableButtons()</i></td>
         <td>Disable "Confirm" and "Cancel" buttons.</td>
       </tr>
@@ -1060,7 +1080,7 @@ swal({
       </tr>
       <tr>
         <td><i>swal.getInput()</i></td>
-        <td>Get input node or array of nodes (radios), this method works with <a href="#input-parameter">input parameter</a>.</td>
+        <td>Get the input DOM node, this method works with <a href="#input-parameter">input parameter</a>.</td>
       </tr>
       <tr>
         <td><i>swal.disableInput()</i></td>

--- a/qunit/tests.js
+++ b/qunit/tests.js
@@ -21,6 +21,36 @@ QUnit.test('modal width', function (assert) {
   assert.equal($('.swal2-modal')[0].style.width, '500px')
 })
 
+QUnit.test('getters', function (assert) {
+  swal('Title', 'Content')
+  assert.equal(swal.getTitle().innerText, 'Title')
+  assert.equal(swal.getContent().innerText, 'Content')
+
+  swal({
+    showCancelButton: true,
+    imageUrl: 'image.png',
+    confirmButtonText: 'Confirm button',
+    cancelButtonText: 'Cancel button'
+  })
+  assert.ok(swal.getImage().src.indexOf('image.png'))
+  assert.equal(swal.getConfirmButton().innerText, 'Confirm button')
+  assert.equal(swal.getCancelButton().innerText, 'Cancel button')
+
+  swal({input: 'text'})
+  $('.swal2-input').val('input text')
+  assert.equal(swal.getInput().value, 'input text')
+
+  swal({
+    input: 'radio',
+    inputOptions: {
+      'one': 'one',
+      'two': 'two'
+    }
+  })
+  $('.swal2-radio input[value="two"]').prop('checked', true)
+  assert.equal(swal.getInput().value, 'two')
+})
+
 QUnit.test('confirm button', function (assert) {
   const done = assert.async()
 

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -352,6 +352,9 @@ const modalDependant = (...args) => {
     // Get input element by specified type or, if type isn't specified, by params.input
     const getInput = (inputType) => {
       inputType = inputType || params.input
+      if (!inputType) {
+        return null
+      }
       switch (inputType) {
         case 'select':
         case 'textarea':
@@ -658,6 +661,10 @@ const modalDependant = (...args) => {
 
     sweetAlert.disableConfirmButton = () => {
       confirmButton.disabled = true
+    }
+
+    sweetAlert.getInput = () => {
+      return getInput()
     }
 
     sweetAlert.enableInput = () => {

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -846,14 +846,12 @@ const modalDependant = (...args) => {
         radio.innerHTML = ''
         populateInputOptions = (inputOptions) => {
           for (let radioValue in inputOptions) {
-            let id = 1
             const radioInput = document.createElement('input')
             const radioLabel = document.createElement('label')
             const radioLabelSpan = document.createElement('span')
             radioInput.type = 'radio'
             radioInput.name = swalClasses.radio
             radioInput.value = radioValue
-            radioInput.id = swalClasses.radio + '-' + (id++)
             if (params.inputValue === radioValue) {
               radioInput.checked = true
             }

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -645,6 +645,13 @@ const modalDependant = (...args) => {
       cancelButton.disabled = false
     }
 
+    sweetAlert.getTitle = () => dom.getTitle()
+    sweetAlert.getContent = () => dom.getContent()
+    sweetAlert.getInput = () => getInput()
+    sweetAlert.getImage = () => dom.getImage()
+    sweetAlert.getConfirmButton = () => dom.getConfirmButton()
+    sweetAlert.getCancelButton = () => dom.getCancelButton()
+
     sweetAlert.enableButtons = () => {
       confirmButton.disabled = false
       cancelButton.disabled = false
@@ -661,10 +668,6 @@ const modalDependant = (...args) => {
 
     sweetAlert.disableConfirmButton = () => {
       confirmButton.disabled = true
-    }
-
-    sweetAlert.getInput = () => {
-      return getInput()
     }
 
     sweetAlert.enableInput = () => {

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -108,14 +108,19 @@ declare module "sweetalert2" {
         function resetValidationError(): void;
 
         /**
-         * Enable input, this method works with input parameter.
+         * Get input, this method works with input parameter.
          */
-        function enableInput(): void;
+        function getInput(): HTMLElement;
 
         /**
          * Disable input.
          */
         function disableInput(): void;
+
+        /**
+        * Enable input, this method works with input parameter.
+        */
+        function enableInput(): void;
 
         /**
          * Provide array of SweetAlert2 parameters to show multiple modals, one modal after another.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -58,6 +58,31 @@ declare module "sweetalert2" {
         function close(onComplete?: (modalElement: HTMLElement) => void): void;
 
         /**
+         * Get the modal title.
+         */
+        function getTitle(): HTMLElement;
+
+        /**
+         * Get the modal content.
+         */
+        function getContent(): HTMLElement;
+
+        /**
+         * Get the image.
+         */
+        function getImage(): HTMLElement;
+
+        /**
+         * Get the "Confirm" button.
+         */
+        function getConfirmButton(): HTMLElement;
+
+        /**
+         * Get the "Cancel" button.
+         */
+        function getCancelButton(): HTMLElement;
+
+        /**
          * Enable "Confirm" and "Cancel" buttons.
          */
         function enableButtons(): void;
@@ -108,17 +133,17 @@ declare module "sweetalert2" {
         function resetValidationError(): void;
 
         /**
-         * Get input, this method works with input parameter.
+         * Get the input DOM node, this method works with input parameter.
          */
         function getInput(): HTMLElement;
 
         /**
-         * Disable input.
+         * Disable input. A disabled input element is unusable and un-clickable.
          */
         function disableInput(): void;
 
         /**
-        * Enable input, this method works with input parameter.
+        * Enable input.
         */
         function enableInput(): void;
 
@@ -210,7 +235,7 @@ declare module "sweetalert2" {
          * It can either be put in the array under the key "type" or passed as the third parameter of the function.
          * Default: null
          */
-            type?: SweetAlertType;
+        type?: SweetAlertType;
 
         /**
          * Input field type, can be text, email, password, number, tel, range, textarea, select, radio, checkbox and file.


### PR DESCRIPTION
Added getters:

- `swal.getTitle()`
- `swal.getContent()`
- `swal.getInput()`
- `swal.getImage()`
- `swal.getConfirmButton()`
- `swal.getCancelButton()`

Related to: 
- #408 
- #412 