### PR TITLE
Fix for button margin on mobile view

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -109,7 +109,7 @@ body {
     cursor: pointer;
     font-size: 17px;
     font-weight: 500;
-    margin: 15px 5px 0;
+    margin: 0 5px;
     padding: 10px 32px;
 
     &:not(.swal2-loading) {
@@ -117,6 +117,10 @@ body {
         opacity: .4;
         cursor: no-drop;
       }
+    }
+    
+    .swal2-styled + .swal2-styled {
+      margin-top: 15px;
     }
 
     &.swal2-loading {

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -109,7 +109,7 @@ body {
     cursor: pointer;
     font-size: 17px;
     font-weight: 500;
-    margin: 0 5px;
+    margin: 15px 5px 0;
     padding: 10px 32px;
 
     &:not(.swal2-loading) {


### PR DESCRIPTION
When the buttons are too wide for the popup, they stack without any spacing.

<img width="263" alt="sweetalert-button-issue" src="https://cloud.githubusercontent.com/assets/4042868/22626413/5b0da4de-eb72-11e6-852c-576267e323ce.png">
