### PR TITLE
Change HTML entity to simple ampersand

### DIFF
--- a/index.html
+++ b/index.html
@@ -1399,7 +1399,7 @@ swal({
     }).then(function () {
       swal({
         type: 'success',
-        text: 'You agreed with T&amp;C :)'
+        text: 'You agreed with T&C :)'
       })
     }).catch(swal.noop)
   })


### PR DESCRIPTION
**Current Behavior**
The current behavior of the success message on this page is that "You agreed with T&amp;C :)" is returned if the checkbox is checked.
![screen shot 2017-02-13 at 3 25 59 pm](https://cloud.githubusercontent.com/assets/2218833/22901789/d6717918-f200-11e6-9ed9-48062b0a6e28.png)

**Proposed Change**
Since the value of the text is escaped, the plain ampersand character can be sent without using the entity.
![screen shot 2017-02-13 at 3 27 12 pm](https://cloud.githubusercontent.com/assets/2218833/22901814/f689b01c-f200-11e6-9394-a566ff5764af.png)

**JS Fiddle of Proposed Change**
[https://jsfiddle.net/mgxrL5jy/](https://jsfiddle.net/mgxrL5jy/)
