### PR TITLE
Added support for `allowEnterKey`

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Configuration
 | `animation`             | `true`               | If set to `false`, modal CSS animation will be disabled. |
 | `allowOutsideClick`     | `true`               | If set to `false`, the user can't dismiss the modal by clicking outside it. |
 | `allowEscapeKey`        | `true`               | If set to `false`, the user can't dismiss the modal by pressing the <kbd>Esc</kbd> key. |
+| `allowEnterKey`        | `true`               | If set to `false`, the user can't confirm the modal by pressing the <kbd>Enter</kbd> or <kbd>Space</kbd> keys, unless they manually focus the confirm button. |
 | `showConfirmButton`     | `true`               | If set to `false`, a "Confirm"-button will not be shown. It can be useful when you're using `html` parameter for custom HTML description. |
 | `showCancelButton`      | `false`              | If set to `true`, a "Cancel"-button will be shown, which the user can click on to dismiss the modal. |
 | `confirmButtonText`     | `'OK'`               | Use this to change the text on the "Confirm"-button. |

--- a/index.html
+++ b/index.html
@@ -484,6 +484,11 @@ swal.queue([{
         <td><i>true</i></td>
         <td>If set to <strong>false</strong>, the user can't dismiss the modal by pressing the Escape key.</td>
       </tr>
+      <tr id="allow-enter-key">
+        <td><b>allowEnterKey</b></td>
+        <td><i>true</i></td>
+        <td>If set to <strong>false</strong>, the user can't confirm the modal by pressing the Enter or Space keys, unless they manually focus the confirm button.</td>
+      </tr>
       <tr>
         <td><b>showConfirmButton</b></td>
         <td><i>true</i></td>

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -598,20 +598,19 @@ const sweetAlert = (...args) => {
         e.preventDefault()
 
       // ENTER/SPACE
-      } else {
-        if (keyCode === 13 || keyCode === 32) {
-          if (btnIndex === -1) {
-            // ENTER/SPACE clicked outside of a button.
-            if (params.focusCancel) {
-              dom.fireClick(cancelButton, e)
-            } else {
-              dom.fireClick(confirmButton, e)
-            }
+      } else if (keyCode === 13 || keyCode === 32) {
+        if (btnIndex === -1) {
+          // ENTER/SPACE clicked outside of a button.
+          if (params.focusCancel) {
+            dom.fireClick(cancelButton, e)
+          } else {
+            dom.fireClick(confirmButton, e)
           }
-        } else if (keyCode === 27 && params.allowEscapeKey === true) {
-          sweetAlert.closeModal(params.onClose)
-          reject('esc')
         }
+      // ESC
+      } else if (keyCode === 27 && params.allowEscapeKey === true) {
+        sweetAlert.closeModal(params.onClose)
+        reject('esc')
       }
     }
 

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -11,7 +11,7 @@ let swal2Observer
  * Set type, text and actions on modal
  */
 const setParameters = (params) => {
-  const modal = dom.getModal() || dom.init()
+  const modal = dom.getModal() || dom.init(params)
 
   for (let param in params) {
     if (!defaultParams.hasOwnProperty(param) && param !== 'extraParams') {
@@ -599,7 +599,7 @@ const sweetAlert = (...args) => {
 
       // ENTER/SPACE
       } else if (keyCode === 13 || keyCode === 32) {
-        if (btnIndex === -1) {
+        if (btnIndex === -1 && params.allowEnterKey) {
           // ENTER/SPACE clicked outside of a button.
           if (params.focusCancel) {
             dom.fireClick(cancelButton, e)
@@ -710,7 +710,7 @@ const sweetAlert = (...args) => {
 
     // Set modal min-height to disable scrolling inside the modal
     sweetAlert.recalculateHeight = dom.debounce(() => {
-      const modal = dom.getModal() || dom.init()
+      const modal = dom.getModal() || dom.init(params)
       const prevState = modal.style.display
       modal.style.minHeight = ''
       dom.show(modal)
@@ -922,7 +922,13 @@ const sweetAlert = (...args) => {
     openModal(params.animation, params.onOpen)
 
     // Focus the first element (input or button)
-    setFocus(-1, 1)
+    if (params.allowEnterKey) {
+      setFocus(-1, 1)
+    } else {
+      if (document.activeElement) {
+        document.activeElement.blur()
+      }
+    }
 
     // fix scroll
     dom.getContainer().scrollTop = 0

--- a/src/utils/default.js
+++ b/src/utils/default.js
@@ -8,6 +8,7 @@ export default {
   animation: true,
   allowOutsideClick: true,
   allowEscapeKey: true,
+  allowEnterKey: true,
   showConfirmButton: true,
   showCancelButton: false,
   preConfirm: null,

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -13,7 +13,7 @@ export const states = {
 /*
  * Add modal + overlay to DOM
  */
-export const init = () => {
+export const init = (params) => {
   if (typeof document === 'undefined') {
     console.error('SweetAlert2 requires document to initialize')
     return
@@ -39,7 +39,7 @@ export const init = () => {
 
   input.onkeydown = (event) => {
     setTimeout(() => {
-      if (event.keyCode === 13) {
+      if (event.keyCode === 13 && params.allowEnterKey) {
         event.stopPropagation()
         sweetAlert.clickConfirm()
       }


### PR DESCRIPTION
Fixes #423.

Added support for `allowEnterKey` to toggle keyboard confirmation. Defaults to `true`, which is the same as the current setup. Setting to to `false` will no longer confirm when pressing <kbd>Enter</kbd> or <kbd>Space</kbd> without a focus or with focus on the input, and will no longer focus the confirm button by default.