### PR TITLE
Better type declaration for inputAttributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.d.ts]
+indent_size = 4

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -201,6 +201,12 @@ declare module "sweetalert2" {
 
     export type SweetAlertInputOptions = { [inputValue: string]: string };
 
+    export type SweetAlertInputAttributes = {
+        [P in keyof HTMLInputElement]?: string;
+    } & {
+        [customAttribute: string]: string;
+    };
+
     export interface SweetAlertOptions {
         /**
          * The title of the modal, as HTML.
@@ -436,7 +442,7 @@ declare module "sweetalert2" {
         inputAutoTrim?: boolean;
 
         /**
-         * HTML input attributes (e.g. min, max, step, accept ...), that are added to the input field.
+         * HTML input attributes (e.g. min, max, step, accept...), that are added to the input field.
          * Default: null
          *
          * ex.
@@ -448,7 +454,7 @@ declare module "sweetalert2" {
          *     }
          *   })
          */
-        inputAttributes?: any;
+        inputAttributes?: SweetAlertInputAttributes;
 
         /**
          * Validator for input field, should return a Promise.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -201,11 +201,7 @@ declare module "sweetalert2" {
 
     export type SweetAlertInputOptions = { [inputValue: string]: string };
 
-    export type SweetAlertInputAttributes = {
-        [P in keyof HTMLInputElement]?: string;
-    } & {
-        [customAttribute: string]: string;
-    };
+    export type SweetAlertInputAttributes = { [attribute: string]: string };
 
     export interface SweetAlertOptions {
         /**


### PR DESCRIPTION
This is a PR to improve the type definition of the `inputAttributes` option, added recenlty by @Fkscorpion in #466.

First, in the [aca4dc3](https://github.com/limonte/sweetalert2/commit/aca4dc372c726210f6bf12d8f3253d09df0db698) commit, I used a mapped type - to allow IDEs to provide auto-completion - in intersection with a standard dictionary, to allow custom attributes and not only `HTMLInputElement`'s ones.

Then, I've decided to remove the mapped type and only keep the dictionary, since this is a bleeding-edge, TypeScript 2.1 feature, so it would break alot of consumers' applications without a single benefit from a static typing point of view (only IDE assistance, but even my IDE is not yet capable of understanding a type intersection with a mapped type, so...).

You'll note that the dictionary maps to `string` and not `any`, because `setAttribute()` (used under the hood in SweetAlert) [takes a string](https://github.com/Microsoft/TypeScript/blob/master/src/lib/dom.generated.d.ts#L3621), and not any value (the DOM API, however, takes typed values, but `setAttribute()` is an HTML thing).

Maybe I will make a new PR about adding a `inputProperties` option that sets `HTMLInputElement` _DOM properties_, and not _HTML attributes_. The DOM API is better to work with than the XML/HTML one, fits most use cases and offers a much better typed experience.

API proposal:

```ts
interface SweetAlertOptions {
    inputProperties?: Partial<HTMLInputElement>;

    // de-sugarified:
    inputProperties?: { [P in keyof HTMLInputElement]?: HTMLInputElement[P] };
}
```