### PR TITLE
Add !default affix to scss colors

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -11,11 +11,11 @@ $apricot: #ea7d7d;
 $corn: #f8d486;
 $manhattan: #f8bb86;
 
-$success:  #a5dc86;
-$error:    #f27474;
-$warning:  #f8bb86;
-$info:     #3fc3ee;
-$question: #87adbd;
+$success:  #a5dc86 !default;
+$error:    #f27474 !default;
+$warning:  #f8bb86 !default;
+$info:     #3fc3ee !default;
+$question: #87adbd !default;
 $success-border: rgba($success, .2);
 
 $overlay: rgba($black, .4);


### PR DESCRIPTION
This is the request from the [CrocodileJS](https://github.com/crocodilejs) framework:
 
> @limonte hey can you do me a favor?  in Sweet Alert 2 — affix `!default` to the SCSS variable definitions so we can easily override them 
that way we can override with bootstrap

```$success: $brand-primary;
$error: $brand-danger;
$warning: $brand-warning;
$info: $brand-info;
$question: $gray-light;
```

> e.g.

```$success:  #a5dc86 !default;
$error:    #f27474 !default;
$warning:  #f8bb86 !default;
$info:     #3fc3ee !default;
$question: #87adbd !default;
```

> in your codebase

---

If anyone has objections against this please let me know, scss is not my strongest skill.