### PR TITLE
Remove es6-promise dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Usage
 -----
 
 ```html
-<script src="bower_components/es6-promise/es6-promise.auto.min.js"></script> <!-- for IE support -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/2.4.1/core.js"></script> <!-- for IE and Android native browser support -->
 
 <script src="bower_components/sweetalert2/dist/sweetalert2.min.js"></script>
 <link rel="stylesheet" type="text/css" href="bower_components/sweetalert2/dist/sweetalert2.min.css">

--- a/bower.json
+++ b/bower.json
@@ -10,9 +10,6 @@
     "Leo Correa <lcorr005@gmail.com> (https://leonardocorrea.com/)",
     "Joseph Schultz (https://github.com/acupajoe)"
   ],
-  "dependencies": {
-    "es6-promise": "*"
-  },
   "ignore": [
     "assets",
     "config",

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 
   <!-- This is what you need -->
-  <script src="https://cdn.jsdelivr.net/es6-promise/latest/es6-promise.auto.min.js"></script> <!-- IE11 support -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/2.4.1/core.js"></script> <!-- IE11 and Android native browser support -->
   <script src="./dist/sweetalert2.js"></script>
   <link rel="stylesheet" href="./dist/sweetalert2.min.css">
   <!--.......................-->
@@ -370,8 +370,8 @@ swal.queue([{
   <div class="center-container">
     <h3>Usage</h3>
     <p>1. Initialize the plugin by referencing the necessary files:</p>
-<pre><span class="comment">&lt;!-- for IE support --&gt;</span>
-&lt;<span class="tag">script</span> <span class="attr">src</span>=<span class="str">"bower_components/es6-promise/es6-promise.auto.min.js"</span>&gt;&lt;/<span class="tag">script</span>&gt;
+<pre><span class="comment">&lt;!-- for IE and Android native browser support --&gt;</span>
+&lt;<span class="tag">script</span> <span class="attr">src</span>=<span class="str">"https://cdnjs.cloudflare.com/ajax/libs/core-js/2.4.1/core.js"</span>&gt;&lt;/<span class="tag">script</span>&gt;
 
 &lt;<span class="tag">script</span> <span class="attr">src</span>=<span class="str">"bower_components/sweetalert2/dist/sweetalert2.min.js"</span>&gt;&lt;/<span class="tag">script</span>&gt;
 &lt;<span class="tag">link</span> <span class="attr">rel</span>=<span class="str">"stylesheet"</span> <span class="tag">href</span>=<span class="str">"bower_components/sweetalert2/dist/sweetalert2.min.css"</span>&gt;</pre>

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
   "main": "dist/sweetalert2.js",
   "jsnext:main": "src/sweetalert2.js",
   "types": "sweetalert2.d.ts",
-  "dependencies": {
-    "es6-promise": "^4.0.5"
-  },
   "devDependencies": {
     "babel-plugin-external-helpers": "latest",
     "babel-plugin-transform-object-assign": "latest",

--- a/qunit/index.html
+++ b/qunit/index.html
@@ -9,7 +9,7 @@
   <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
   <script src="https://code.jquery.com/qunit/qunit-2.1.1.js"></script>
 
-  <script src="https://cdn.jsdelivr.net/es6-promise/latest/es6-promise.auto.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/2.4.1/core.js"></script>
   <script src="../dist/sweetalert2.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Make SweetAlert2 ~~great again~~ a plugin with zero dependencies :tada: 

Connected to 

 - https://github.com/limonte/sweetalert2/issues/325
 - https://github.com/limonte/sweetalert2/issues/492 
 - https://github.com/limonte/sweetalert2/issues/416
 - https://github.com/limonte/sweetalert2/issues/166