### PR TITLE
Set node_js to 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 dist: trusty
-node_js: 8
+node_js: 8.0
 
 addons:
   firefox: latest


### PR DESCRIPTION
There's something wrong with npm 5.3.0: https://travis-ci.org/limonte/sweetalert2/builds/255783170

Set node_js to 8.0 and npm to 5.0 to fix that.