### PR TITLE
Target as string or element (with tests)

### DIFF
--- a/qunit/tests.js
+++ b/qunit/tests.js
@@ -277,7 +277,6 @@ QUnit.test('input select', function (assert) {
 
 QUnit.test('input checkbox', function (assert) {
   const done = assert.async()
-  const checkbox = $('.swal2-checkbox input')
 
   swal({input: 'checkbox', inputAttributes: {name: 'test-checkbox'}}).then(function (result) {
     assert.equal(checkbox.attr('name'), 'test-checkbox')
@@ -285,6 +284,7 @@ QUnit.test('input checkbox', function (assert) {
     done()
   })
 
+  const checkbox = $('.swal2-checkbox input')
   checkbox.prop('checked', true)
   swal.clickConfirm()
 })
@@ -553,6 +553,8 @@ QUnit.test('modal vertical offset', function (assert) {
 })
 
 QUnit.test('target', function (assert) {
+  const warn = console.warn // Suppress the warnings
+  console.warn = () => true // Suppress the warnings
   swal('Default target')
   assert.equal(document.body, document.querySelector('.swal2-container').parentNode)
   swal.close()
@@ -572,6 +574,7 @@ QUnit.test('target', function (assert) {
   swal({ title: 'Custom invalid target (element)', target: true })
   assert.equal(document.body, document.querySelector('.swal2-container').parentNode)
   swal.close()
+  console.warn = warn // Suppress the warnings
 })
 
 QUnit.test('onOpen', function (assert) {

--- a/qunit/tests.js
+++ b/qunit/tests.js
@@ -557,8 +557,21 @@ QUnit.test('target', function (assert) {
   assert.equal(document.body, document.querySelector('.swal2-container').parentNode)
   swal.close()
 
-  swal({title: 'Custom target', target: '#qunit'})
+  swal({title: 'Custom valid target (string)', target: '#qunit'}) //switch targets
   assert.equal(document.querySelector('#qunit'), document.querySelector('.swal2-container').parentNode)
+  swal.close()
+
+  swal({title: 'Custom invalid target (string)', target: 'lorem_ipsum'}) //switch targets
+  assert.equal(document.body, document.querySelector('.swal2-container').parentNode)
+  swal.close()
+
+  swal({ title: 'Custom valid target (element)', target: $('#qunit')[0] })
+  assert.equal($('#qunit')[0], document.querySelector('.swal2-container').parentNode)
+  swal.close()
+
+  swal({ title: 'Custom invalid target (element)', target: true })
+  assert.equal(document.body, document.querySelector('.swal2-container').parentNode)
+  swal.close()
 })
 
 QUnit.test('onOpen', function (assert) {

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -11,7 +11,21 @@ let swal2Observer
  * Set type, text and actions on modal
  */
 const setParameters = (params) => {
-  const modal = dom.getModal() || dom.init(params)
+  // If a custom element is set, determine if it is valid
+  if ((typeof params.target === 'string' && !document.querySelector(params.target)) || (typeof params.target !== 'string' && !params.target.appendChild)) {
+    console.warn('SweetAlert2: Target parameter is not valid, defaulting to "body"')
+    params.target = 'body'
+  }
+
+  let modal
+  const oldModal = dom.getModal()
+  let targetElement = typeof params.target === 'string' ? document.querySelector(params.target) : params.target
+  // If the model target has changed, refresh the modal
+  if (oldModal && targetElement && oldModal.parentNode !== targetElement.parentNode) {
+    modal = dom.init(params)
+  } else {
+    modal = oldModal || dom.init(params)
+  }
 
   for (let param in params) {
     if (!defaultParams.hasOwnProperty(param) && param !== 'extraParams') {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -15,6 +15,12 @@ export const states = {
  * Add modal + overlay to DOM
  */
 export const init = (params) => {
+  // Clean up old modals
+  while (getContainer()) {
+    const c = getContainer()
+    c.parentNode.removeChild(c)
+  }
+
   if (typeof document === 'undefined') {
     console.error('SweetAlert2 requires document to initialize')
     return
@@ -25,10 +31,6 @@ export const init = (params) => {
   container.innerHTML = sweetHTML
 
   let targetElement = typeof params.target === 'string' ? document.querySelector(params.target) : params.target
-  if (!targetElement) {
-    console.warn(`SweetAlert2: Can't find the target "${params.target}"`)
-    targetElement = document.body
-  }
   targetElement.appendChild(container)
 
   const modal = getModal()

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -24,7 +24,7 @@ export const init = (params) => {
   container.className = swalClasses.container
   container.innerHTML = sweetHTML
 
-  let targetElement = document.querySelector(params.target)
+  let targetElement = typeof params.target === 'string' ? document.querySelector(params.target) : params.target
   if (!targetElement) {
     console.warn(`SweetAlert2: Can't find the target "${params.target}"`)
     targetElement = document.body

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -15,9 +15,9 @@ export const states = {
  * Add modal + overlay to DOM
  */
 export const init = (params) => {
-  // Clean up old modals
-  while (getContainer()) {
-    const c = getContainer()
+  // Clean up the old modal if it exists
+  const c = getContainer()
+  if (c) {
     c.parentNode.removeChild(c)
   }
 


### PR DESCRIPTION
PR for #571 (and PR #573)

This is building off of what @erickmonteiro did. I just added a couple tests and a warning.

I found that If you try to make a swal with a different target than your last swal, it just uses the last one, so I had to fix that before the tests would pass so I:
- Added a separate invalid string test and one valid and one invalid element tests.
- Made sure that if the target (string or element) is invalid, it is changed to "body"
- Made sure that if the target changes from the last modal, a new swal is made
- Made sure every time `dom.init` is called, it removes all the modals that we don't need.
- Removed the newly redundant warning in `dom.init` since it was replaced in `sweetalert2.setParameters`

I'm fairly certain this is what was needed, tell me if I missed something.
