### PR TITLE
Order focusable elements according to their tabindex

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -989,7 +989,7 @@ const sweetAlert = (...args) => {
 
     openModal(params.animation, params.onOpen)
 
-    // Focus the first element (input or button)
+    // Focus the first focusable element
     if (params.allowEnterKey) {
       setFocus(-1, 1)
     } else {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -161,10 +161,27 @@ export const getFocusableElements = (focusCancel) => {
   if (focusCancel) {
     buttons.reverse()
   }
-  const focusableElements = buttons.concat(Array.prototype.slice.call(
-    getModal().querySelectorAll('button, input:not([type=hidden]), textarea, select, a, *[tabindex]:not([tabindex="-1"])')
-  ))
-  return uniqueArray(focusableElements)
+
+  const focusableElementsWithTabindex = Array.from(
+    getModal().querySelectorAll('[tabindex]:not([tabindex="-1"]):not([tabindex="0"])')
+  )
+  // sort according to tabindex
+  .sort((a, b) => {
+    a = parseInt(a.getAttribute('tabindex'))
+    b = parseInt(b.getAttribute('tabindex'))
+    if (a > b) {
+      return 1
+    } else if (a < b) {
+      return -1
+    }
+    return 0
+  })
+
+  const otherFocusableElements = Array.prototype.slice.call(
+    getModal().querySelectorAll('button, input:not([type=hidden]), textarea, select, a, [tabindex="0"]')
+  )
+
+  return uniqueArray(buttons.concat(focusableElementsWithTabindex, otherFocusableElements))
 }
 
 export const hasClass = (elem, className) => {


### PR DESCRIPTION
When user press <kbd>tab</kbd>, the next focusable element inside the modal should be focused. 

Until now, swal2 wasn't respect the `tabindex` attribute of focusable elements, this PR fixes that.