### PR TITLE
Allow for jQuery objects in `html` property in TS definitions

### DIFF
--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -238,7 +238,7 @@ declare module 'sweetalert2' {
          *
          * @default null
          */
-        html?: string;
+        html?: string|JQuery;
 
         /**
          * The type of the modal.
@@ -576,4 +576,15 @@ declare module 'sweetalert2' {
     }
 
     export default swal;
+}
+
+/**
+ * These interfaces aren't provided by SweetAlert2, but its definitions use them.
+ * They will be merged with 'true' definitions.
+ */
+
+interface JQuery {
+}
+
+interface Promise<T> {
 }


### PR DESCRIPTION
According to [swal2 page](https://limonte.github.io/sweetalert2/), we can put jQuery objects in the `html` property of options. TS definitions didn't allow that.