### PR TITLE
Add blurBackground option

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Configuration
 | `onOpen`                | `null`               | Function to run when modal opens, provides modal DOM element as the first argument. |
 | `onClose`               | `null`               | Function to run when modal closes, provides modal DOM element as the first argument. |
 | `useRejections`         | `true`               | Determines whether dismissals (outside click, cancel button, close button, esc key) should reject, or resolve with an object of the format `{ dismiss: reason }`. Set it to `false` to get a cleaner control flow when using `await`, as explained in [#485](https://github.com/limonte/sweetalert2/issues/485). |
+| `blurBackground`         | `false`               | Blurs the background around the SweetAlert window. |
 
 You can redefine default params by using `swal.setDefaults(customParams)` where `customParams` is an object.
 

--- a/index.html
+++ b/index.html
@@ -116,6 +116,19 @@ swal(
 )</pre>
     </li>
 
+    <li class="blurred">
+      <div class="ui">
+        <p>A basic message with blurred background <b>(EXPERIMENTAL)</b></p>
+        <button aria-label="Try me! Example: A basic message with blurred background">Try me!</button>
+      </div>
+      <pre>
+swal({
+  text: <span class="str">'Can you see me?'</span>,
+  blurBackground: true
+})
+      </pre>
+    </li>
+
     <li class="timer">
       <div class="ui">
         <p>A message with auto close timer</p>
@@ -1265,6 +1278,13 @@ swal({
 
   $('.examples .success button').on('click', function () {
     swal('Good job!', 'You clicked the button!', 'success').catch(swal.noop)
+  })
+
+  $('.examples .blurred button').on('click', function () {
+    swal({
+      text: 'Can you see me?',
+      blurBackground: true
+    })
   })
 
   $('.examples .warning.confirm button').on('click', function () {

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -279,6 +279,7 @@ const openModal = (animation, onComplete) => {
     container.style.overflowY = 'auto'
   }
 
+  dom.addClass(document.documentElement, swalClasses.blur)
   dom.addClass(document.documentElement, swalClasses.shown)
   dom.addClass(document.body, swalClasses.shown)
   dom.addClass(container, swalClasses.shown)
@@ -1105,6 +1106,17 @@ sweetAlert.close = sweetAlert.closeModal = (onComplete) => {
     dom.removeClass(document.body, swalClasses.shown)
     undoScrollbar()
     undoIOSfix()
+
+    // if blur background is enabled, unblur the background
+    // and put back the body elements
+    if (dom.hasClass(document.documentElement, swalClasses.blur)) {
+      dom.removeClass(document.documentElement, swalClasses.blur)
+      var backgroundContainer = document.getElementsByClassName(swalClasses.background)[0]
+      while (backgroundContainer.firstChild) {
+        document.body.appendChild(backgroundContainer.firstChild)
+      }
+      document.body.removeChild(backgroundContainer)
+    }
   }
 
   // If animation is supported, animate

--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -15,6 +15,22 @@ body {
   }
 }
 
+.swal2-blur .swal2-background {
+	-webkit-filter: blur(4px);
+    -moz-filter: blur(4px);
+    -o-filter: blur(4px);
+    -ms-filter: blur(4px);
+    filter: blur(4px);
+}
+
+.swal2-blur .swal2-container {
+	-webkit-filter: blur(0px) !important;
+    -moz-filter: blur(0px);
+    -o-filter: blur(0px);
+    -ms-filter: blur(0px);
+    filter: blur(0px) !important;
+}
+
 .swal2-container {
   // centering
   display: flex;

--- a/src/utils/classes.js
+++ b/src/utils/classes.js
@@ -40,7 +40,9 @@ export const swalClasses = prefix([
   'progresscircle',
   'progressline',
   'loading',
-  'styled'
+  'styled',
+  'blur',
+  'background'
 ])
 
 export const iconTypes = prefix([

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -30,6 +30,15 @@ export const init = (params) => {
   container.className = swalClasses.container
   container.innerHTML = sweetHTML
 
+  if (params.blurBackground) {
+    const backgroundContainer = document.createElement('div')
+    backgroundContainer.className = swalClasses.background
+    while (document.body.firstChild) {
+      backgroundContainer.appendChild(document.body.firstChild)
+    }
+    document.body.appendChild(backgroundContainer)
+  }
+
   let targetElement = typeof params.target === 'string' ? document.querySelector(params.target) : params.target
   targetElement.appendChild(container)
 

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -45,5 +45,6 @@ export default {
   progressStepsDistance: '40px',
   onOpen: null,
   onClose: null,
-  useRejections: true
+  useRejections: true,
+  blurBackground: false
 }


### PR DESCRIPTION
This PR adds a `blurBackground` option, with the default value of `false` (since it's experimental), that adds a blur on the background behind the modal window.

```
swal({
      text: 'Can you see me?',
      blurBackground: true
    })
```

![https://s26.postimg.org/xknysnk95/Captura_de_Tela_2017-08-29_a_s_13.27.12.png](https://s26.postimg.org/xknysnk95/Captura_de_Tela_2017-08-29_a_s_13.27.12.png)