### PR TITLE
Add focusConfirm parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Configuration
 | `cancelButtonAriaLabel`  | `''`                 | Use this to change the `aria-label` for the "Cancel"-button. |
 | `buttonsStyling`         | `true`               | Apply default styling to buttons. If you want to use your own classes (e.g. Bootstrap classes) set this parameter to `false`. |
 | `reverseButtons`         | `false`              | Set to `true` if you want to invert default buttons positions ("Confirm"-button on the right side). |
+| `focusConfirm`           | `true`               | Set to `false` if you want to focus the first element in tab order instead of "Confirm"-button by default. |
 | `focusCancel`            | `false`              | Set to `true` if you want to focus the "Cancel"-button by default. |
 | `showCloseButton`        | `false`              | Set to `true` to show close button in top right corner of the modal. |
 | `showLoaderOnConfirm`    | `false`              | Set to `true` to disable buttons and show that something is loading. Use it in combination with the `preConfirm` parameter. |

--- a/index.html
+++ b/index.html
@@ -147,6 +147,7 @@ swal({
     <span class="str">'and other HTML tags'</span>,
   showCloseButton: <span class="val">true</span>,
   showCancelButton: <span class="val">true</span>,
+  focusConfirm: <span class="val">false</span>
   confirmButtonText:
     <span class="str">'&lt;i class="fa fa-thumbs-up"&gt;&lt;/i&gt; Great!'</span>,
   confirmButtonAriaLabel: <span class="str">'Thumbs up, great!'</span>,
@@ -560,6 +561,11 @@ swal.queue([{
         <td><b>reverseButtons</b></td>
         <td><i>false</i></td>
         <td>Set to <strong>true</strong> if you want to invert default buttons positions ("Confirm"-button on the right side).</td>
+      </tr>
+      <tr>
+        <td><b>focusConfirm</b></td>
+        <td><i>true</i></td>
+        <td> Set to <strong>false</strong> if you want to focus the first element in tab order instead of "Confirm"-button by default.</td>
       </tr>
       <tr>
         <td><b>focusCancel</b></td>
@@ -1328,6 +1334,7 @@ swal({
         'and other HTML tags',
       showCloseButton: true,
       showCancelButton: true,
+      focusConfirm: false,
       confirmButtonText: '<i class="fa fa-thumbs-up"></i> Great!',
       confirmButtonAriaLabel: 'Thumbs up, great!',
       cancelButtonText: '<i class="fa fa-thumbs-down"></i>',

--- a/qunit/tests.js
+++ b/qunit/tests.js
@@ -507,7 +507,22 @@ QUnit.test('reversed buttons', function (assert) {
   assert.ok($('.swal2-cancel').index() - $('.swal2-confirm').index() === 1)
 })
 
-QUnit.test('focus cancel', function (assert) {
+QUnit.test('focusConfirm', function (assert) {
+  swal({
+    showCancelButton: true
+  })
+  assert.ok(document.activeElement === $('.swal2-confirm')[0])
+
+  const anchor = $('<a href>link</a>')
+  swal({
+    html: anchor,
+    showCancelButton: true,
+    focusConfirm: false
+  })
+  assert.ok(document.activeElement.outerHTML === anchor[0].outerHTML)
+})
+
+QUnit.test('focusCancel', function (assert) {
   swal({
     text: 'Modal with Cancel button focused',
     showCancelButton: true,

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -677,19 +677,6 @@ const sweetAlert = (...args) => {
           confirmButton.focus()
         }
 
-      // ENTER/SPACE
-      } else if (keyCode === 13 || keyCode === 32) {
-        if (btnIndex === -1 && params.allowEnterKey) {
-          // ENTER/SPACE clicked outside of a button.
-          if (params.focusCancel) {
-            dom.fireClick(cancelButton, e)
-          } else {
-            dom.fireClick(confirmButton, e)
-          }
-          e.stopPropagation()
-          e.preventDefault()
-        }
-
       // ESC
       } else if (keyCode === 27 && params.allowEscapeKey === true) {
         sweetAlert.closeModal(params.onClose)
@@ -1007,13 +994,16 @@ const sweetAlert = (...args) => {
 
     openModal(params.animation, params.onOpen)
 
-    // Focus the first focusable element
-    if (params.allowEnterKey) {
-      setFocus(-1, 1)
-    } else {
+    if (!params.allowEnterKey) {
       if (document.activeElement) {
         document.activeElement.blur()
       }
+    } else if (params.focusCancel && dom.isVisible(cancelButton)) {
+      cancelButton.focus()
+    } else if (params.focusConfirm && dom.isVisible(confirmButton)) {
+      confirmButton.focus()
+    } else {
+      setFocus(-1, 1)
     }
 
     // fix scroll

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,5 +1,3 @@
-/* global MouseEvent */
-
 import { default as sweetAlert } from '../sweetalert2.js'
 import { swalClasses, iconTypes } from './classes.js'
 import { uniqueArray } from './utils.js'
@@ -156,12 +154,7 @@ export const getCancelButton = () => elementByClass(swalClasses.cancel)
 
 export const getCloseButton = () => elementByClass(swalClasses.close)
 
-export const getFocusableElements = (focusCancel) => {
-  const buttons = [getConfirmButton(), getCancelButton()]
-  if (focusCancel) {
-    buttons.reverse()
-  }
-
+export const getFocusableElements = () => {
   const focusableElementsWithTabindex = Array.from(
     getModal().querySelectorAll('[tabindex]:not([tabindex="-1"]):not([tabindex="0"])')
   )
@@ -181,7 +174,7 @@ export const getFocusableElements = (focusCancel) => {
     getModal().querySelectorAll('button, input:not([type=hidden]), textarea, select, a, [tabindex="0"]')
   )
 
-  return uniqueArray(buttons.concat(focusableElementsWithTabindex, otherFocusableElements))
+  return uniqueArray(focusableElementsWithTabindex.concat(otherFocusableElements))
 }
 
 export const hasClass = (elem, className) => {
@@ -258,33 +251,6 @@ export const removeStyleProperty = (elem, property) => {
     elem.style.removeProperty(property)
   } else {
     elem.style.removeAttribute(property)
-  }
-}
-
-export const fireClick = (node) => {
-  if (!isVisible(node)) {
-    return false
-  }
-
-  // Taken from http://www.nonobtrusive.com/2011/11/29/programatically-fire-crossbrowser-click-event-with-javascript/
-  // Then fixed for today's Chrome browser.
-  if (typeof MouseEvent === 'function') {
-    // Up-to-date approach
-    const mevt = new MouseEvent('click', {
-      view: window,
-      bubbles: false,
-      cancelable: true
-    })
-    node.dispatchEvent(mevt)
-  } else if (document.createEvent) {
-    // Fallback
-    const evt = document.createEvent('MouseEvents')
-    evt.initEvent('click', false, false)
-    node.dispatchEvent(evt)
-  } else if (document.createEventObject) {
-    node.fireEvent('onclick')
-  } else if (typeof node.onclick === 'function') {
-    node.onclick()
   }
 }
 

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -23,6 +23,7 @@ export default {
   cancelButtonClass: null,
   buttonsStyling: true,
   reverseButtons: false,
+  focusConfirm: true,
   focusCancel: false,
   showCloseButton: false,
   showLoaderOnConfirm: false,

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -414,6 +414,13 @@ declare module 'sweetalert2' {
         reverseButtons?: boolean;
 
         /**
+         * Set to false if you want to focus the first element in tab order instead of "Confirm"-button by default.
+         *
+         * @default true
+         */
+        focusConfirm?: boolean;
+
+        /**
          * Set to true if you want to focus the "Cancel"-button by default.
          *
          * @default false


### PR DESCRIPTION
Connected to #564 

The `focusConfirm` option if set to `false` will allow users to prevent autofocusing the confirm-button in cases like https://limonte.github.io/sweetalert2/#custom-html when most likely the expected initial focus should be on the link. 