### PR TITLE
Add aria-modal=true

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -78,7 +78,7 @@ export const init = (params) => {
  */
 
 const sweetHTML = `
- <div role="dialog" aria-labelledby="${swalClasses.title}" aria-describedby="${swalClasses.content}" class="${swalClasses.modal}" tabindex="-1">
+ <div role="dialog" aria-modal="true" aria-labelledby="${swalClasses.title}" aria-describedby="${swalClasses.content}" class="${swalClasses.modal}" tabindex="-1">
    <ul class="${swalClasses.progresssteps}"></ul>
    <div class="${swalClasses.icon} ${iconTypes.error}">
      <span class="swal2-x-mark"><span class="swal2-x-mark-line-left"></span><span class="swal2-x-mark-line-right"></span></span>


### PR DESCRIPTION
Connected to #564 

From https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html#rps_label

> `aria-modal=true` tells assistive technologies that the windows underneath the current dialog are not available for interaction (inert).
