### PR TITLE
Docs: import swal from 'sweetalert2/dist/sweetalert2.all.min.js'

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Or:
 
 ```js
 // ES6 Modules or TypeScript
-import swal from 'sweetalert2'
+import swal from 'sweetalert2/dist/sweetalert2.all.min.js'
 
 // CommonJS
 const swal = require('sweetalert2')

--- a/index.html
+++ b/index.html
@@ -390,7 +390,7 @@ swal.queue([{
 &lt;<span class="tag">link</span> <span class="attr">rel</span>=<span class="str">"stylesheet"</span> <span class="tag">href</span>=<span class="str">"bower_components/sweetalert2/dist/sweetalert2.min.css"</span>&gt;</pre>
       <p>Or</p>
 <pre><span class="comment">// ES6 Modules or TypeScript</span>
-<span class="val">import</span> swal <span class="val">from</span> <span class="str">'sweetalert2'</span>
+<span class="val">import</span> swal <span class="val">from</span> <span class="str">'sweetalert2/dist/sweetalert2.all.min.js'</span>
 
 <span class="comment">// CommonJS</span>
 <span class="val">const</span> swal = <span class="func">require</span>(<span class="str">'sweetalert2'</span>)</pre>


### PR DESCRIPTION
There are a lot of confusions about importing CSS separately, so I think it's better to show how to import `sweetalert2.all.min.js`, even if it's temporary and in the next major `sweetalert2.all.min.js` will be the default entry point.

Fixes #659 