### PR TITLE
Remove min-height from the modal

### DIFF
--- a/assets/example.css
+++ b/assets/example.css
@@ -196,7 +196,7 @@ pre {
   pre .func {
     color: #66d9ef; }
   pre .val {
-    color: #e3dcff; }
+    color: #c3bcff; }
   pre .tag {
     color: #f77; }
   pre .attr {

--- a/assets/example.scss
+++ b/assets/example.scss
@@ -13,7 +13,7 @@ $chateaugray: #a7adb2;
 $curiousblue: #3085d6;
 $porcelain: #e2e5e8;
 $pear: #a6e22d;
-$fog: #e3dcff;
+$melrose: #c3bcff;
 $spray: #66d9ef;
 $chenin: #e6db74;
 $armadillo: #49483e;
@@ -299,7 +299,7 @@ pre {
   }
 
   .val {
-    color: $fog;
+    color: $melrose;
   }
 
   .tag {

--- a/index.html
+++ b/index.html
@@ -112,6 +112,17 @@ swal(
 )</pre>
     </li>
 
+    <li id="long-text">
+      <div class="ui">
+        <p>A modal window with a long text inside:</p>
+        <button aria-label="Try me! Example: A modal window with a long text inside">Try me!</button>
+      </div>
+      <pre>
+swal({
+  html: <span class="str">'Less is more.&lt;br>'</span>.repeat(<span class="val">100</span>)
+})</pre>
+    </li>
+
     <li class="html" id="custom-html">
       <div class="ui">
         <p>Custom HTML description and buttons with ARIA labels</p>
@@ -1375,6 +1386,10 @@ swal({
 
   $('.examples .error button').on('click', function () {
     swal('Oops...', 'Something went wrong!', 'error').catch(swal.noop)
+  })
+
+  $('.examples #long-text button').on('click', function () {
+    swal({html: 'Less is more.<br>'.repeat(100)}).catch(swal.noop)
   })
 
   $('.examples .warning.confirm button').on('click', function () {

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -5,7 +5,6 @@ import * as dom from './utils/dom.js'
 
 let modalParams = Object.assign({}, defaultParams)
 let queue = []
-let swal2Observer
 
 /*
  * Check for the existence of Promise
@@ -783,19 +782,6 @@ const sweetAlert = (...args) => {
       }
     }
 
-    // Set modal min-height to disable scrolling inside the modal
-    sweetAlert.recalculateHeight = dom.debounce(() => {
-      const modal = dom.getModal()
-      if (!modal) {
-        return
-      }
-      const prevState = modal.style.display
-      modal.style.minHeight = ''
-      dom.show(modal)
-      modal.style.minHeight = (modal.scrollHeight + 1) + 'px'
-      modal.style.display = prevState
-    }, 50)
-
     // Show block with validation error
     sweetAlert.showValidationError = (error) => {
       const validationError = dom.getValidationError()
@@ -815,7 +801,6 @@ const sweetAlert = (...args) => {
     sweetAlert.resetValidationError = () => {
       const validationError = dom.getValidationError()
       dom.hide(validationError)
-      sweetAlert.recalculateHeight()
 
       const input = getInput()
       if (input) {
@@ -1018,12 +1003,6 @@ const sweetAlert = (...args) => {
 
     // fix scroll
     dom.getContainer().scrollTop = 0
-
-    // Observe changes inside the modal and adjust height
-    if (typeof MutationObserver !== 'undefined' && !swal2Observer) {
-      swal2Observer = new MutationObserver(sweetAlert.recalculateHeight)
-      swal2Observer.observe(modal, {childList: true, characterData: true, subtree: true})
-    }
   })
 }
 


### PR DESCRIPTION
`min-height` isn't needed after switching from having one DOM element all the time to dynamic adding/removing the container and modal. 

Fixes #666 