### PR TITLE
Add onBeforeOpen param to call function when dialog is built but not show yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Configuration
 | `progressSteps`          | `[]`                  | Progress steps, useful for modal queues, see <a href="https://limonte.github.io/sweetalert2/#chaining-modals">usage example</a>. |
 | `currentProgressStep`    | `null`                | Current active progress step. The default is `swal.getQueueStep()`. |
 | `progressStepsDistance`  | `'40px'`              | Distance between progress steps. |
+| `onBeforeOpen`           | `null`                | Function to run when modal built, but not shown yet. Provides modal DOM element as the first argument. |
 | `onOpen`                 | `null`                | Function to run when modal opens, provides modal DOM element as the first argument. |
 | `onClose`                | `null`                | Function to run when modal closes, provides modal DOM element as the first argument. |
 | `useRejections`          | `true`                | Determines whether dismissals (outside click, cancel button, close button, esc key) should reject, or resolve with an object of the format `{ dismiss: reason }`. Set it to `false` to get a cleaner control flow when using `await`, as explained in [#485](https://github.com/limonte/sweetalert2/issues/485). |

--- a/index.html
+++ b/index.html
@@ -673,6 +673,11 @@ swal.queue([{
         <td>Distance between progress steps.</td>
       </tr>
       <tr>
+        <td><b>onBeforeOpen</b></td>
+        <td><i>null</i></td>
+        <td>Function to run when modal built, but not shown yet. Provides modal DOM element as the first argument.</td>
+      </tr>
+      <tr>
         <td><b>onOpen</b></td>
         <td><i>null</i></td>
         <td>Function to run when modal opens, provides modal DOM element as the first argument.</td>

--- a/qunit/tests.js
+++ b/qunit/tests.js
@@ -616,6 +616,32 @@ QUnit.test('onOpen', function (assert) {
     }
   })
 })
+
+QUnit.test('onBeforeOpen', function (assert) {
+  const done = assert.async()
+
+  // create a modal with an onBeforeOpen callback
+  swal({
+    title: 'onBeforeOpen test',
+    onBeforeOpen: function ($modal) {
+      assert.ok($('.swal2-modal').is($modal))
+    }
+  })
+
+  // check that onBeforeOpen calls properly
+  const dynamicTitle = 'Set onBeforeOpen title'
+  swal({
+    title: 'onBeforeOpen test',
+    onBeforeOpen: function ($modal) {
+      $('.swal2-title').html(dynamicTitle)
+    },
+    onOpen: function () {
+      assert.equal($('.swal2-title').html(), dynamicTitle)
+      done()
+    }
+  })
+})
+
 QUnit.test('onClose', function (assert) {
   const done = assert.async()
 

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -269,9 +269,13 @@ const setParameters = (params) => {
 /*
  * Animations
  */
-const openModal = (animation, onComplete) => {
+const openModal = (animation, onBeforeOpen, onComplete) => {
   const container = dom.getContainer()
   const modal = dom.getModal()
+
+  if (onBeforeOpen !== null && typeof onBeforeOpen === 'function') {
+    onBeforeOpen(modal)
+  }
 
   if (animation) {
     dom.addClass(modal, swalClasses.show)
@@ -1002,7 +1006,7 @@ const sweetAlert = (...args) => {
       }
     }
 
-    openModal(params.animation, params.onOpen)
+    openModal(params.animation, params.onBeforeOpen, params.onOpen)
 
     if (!params.allowEnterKey) {
       if (document.activeElement) {

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -48,6 +48,7 @@ export default {
   progressSteps: [],
   currentProgressStep: null,
   progressStepsDistance: '40px',
+  onBeforeOpen: null,
   onOpen: null,
   onClose: null,
   useRejections: true

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -594,6 +594,13 @@ declare module 'sweetalert2' {
         progressStepsDistance?: string;
 
         /**
+         * Function to run when modal built, but not shown yet. Provides modal DOM element as the first argument.
+         *
+         * @default null
+         */
+        onBeforeOpen?: (modalElement: HTMLElement) => void;
+
+        /**
          * Function to run when modal opens, provides modal DOM element as the first argument.
          *
          * @default null


### PR DESCRIPTION
I try to use `onOpen` but have some glitches, because function calls was when dialog already shown.

So I add `onBeforeOpen` param that can accept function to call in showModal before animation classes will be added.