### PR TITLE
Type-check and lint the TypeScript declaration file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,8 @@ const rename = require('gulp-rename')
 const autoprefix = require('gulp-autoprefixer')
 const standard = require('gulp-standard')
 const sassLint = require('gulp-sass-lint')
+const ts = require('gulp-typescript');
+const tslint = require('gulp-tslint');
 
 const pack = require('./package.json')
 const utils = require('./config/utils.js')
@@ -57,7 +59,12 @@ gulp.task('sass', ['sass-lint'], () => {
     .pipe(gulp.dest('assets'))
 })
 
-gulp.task('lint', ['js-lint', 'sass-lint'])
+gulp.task('ts', ['ts-lint'], () => {
+  return gulp.src('sweetalert2.d.ts')
+    .pipe(ts())
+});
+
+gulp.task('lint', ['js-lint', 'sass-lint', 'ts-lint'])
 
 gulp.task('js-lint', () => {
   return gulp.src(['src/**/*.js', 'test/*.js'])
@@ -74,7 +81,13 @@ gulp.task('sass-lint', () => {
     .pipe(sassLint.failOnError())
 })
 
-gulp.task('default', ['compress', 'sass'])
+gulp.task('ts-lint', () => {
+  return gulp.src('sweetalert2.d.ts')
+    .pipe(tslint({ formatter: 'verbose' }))
+    .pipe(tslint.report())
+});
+
+gulp.task('default', ['compress', 'sass', 'ts'])
 
 gulp.task('watch', () => {
   gulp.watch([

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "rollup-plugin-collect-sass": "^1.0.9",
     "standard": "^8.0.0",
     "testem": "latest",
+    "tslint": "^5.8.0",
+    "typescript": "^2.5.3",
     "uglify-js": "latest",
     "yargs": "latest"
   },
@@ -63,6 +65,8 @@
   },
   "scripts": {
     "test": "testem ci",
+    "lint-dts": "tslint sweetalert2.d.ts --format verbose",
+    "check-dts": "tsc sweetalert2.d.ts && npm run lint-dts",
     "assume-dist-unchanged": "git ls-files dist | tr '\\n' ' ' | xargs git update-index --assume-unchanged",
     "no-assume-dist-unchanged": "git ls-files dist | tr '\\n' ' ' | xargs git update-index --no-assume-unchanged"
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "gulp-sass": "latest",
     "gulp-sass-lint": "latest",
     "gulp-standard": "^8.0.0",
+    "gulp-tslint": "^8.1.2",
+    "gulp-typescript": "^3.2.3",
     "gulp-uglify": "latest",
     "rollup": "latest",
     "rollup-plugin-babel": "^3.0.2",

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -314,7 +314,7 @@ declare module 'sweetalert2' {
          *
          * @default false
          */
-        grow?: 'row' | 'column' | 'fullscreen' | boolean;
+        grow?: 'row' | 'column' | 'fullscreen' | false;
 
         /**
          * A custom CSS class for the modal.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -23,7 +23,8 @@ declare module 'sweetalert2' {
     function swal(settings: SweetAlertOptions): Promise<any>;
 
     /**
-     * A namespace inside the default function, containing utility function for controlling the currently-displayed modal.
+     * A namespace inside the default function, containing utility function for controlling the currently-displayed
+     * modal.
      *
      * ex.
      *   import swal from 'sweetalert2';
@@ -155,12 +156,12 @@ declare module 'sweetalert2' {
         /**
          * Provide array of SweetAlert2 parameters to show multiple modals, one modal after another.
          */
-        function queue(steps: (SweetAlertOptions|string)[]): Promise<any>;
+        function queue(steps: Array<SweetAlertOptions | string>): Promise<any>;
 
         /**
          * Get the index of current modal in queue. When there's no active queue, null will be returned.
          */
-        function getQueueStep(): string|null;
+        function getQueueStep(): string | null;
 
         /**
          * Insert a modal to queue, you can specify modal positioning with second parameter.
@@ -205,13 +206,19 @@ declare module 'sweetalert2' {
         function noop(): void;
     }
 
-    export type SweetAlertType = 'success'|'error'|'warning'|'info'|'question'|undefined;
+    export type SweetAlertType = 'success' | 'error' | 'warning' | 'info' | 'question' | undefined;
 
-    export type SweetAlertInputType = 'text'|'email'|'password'|'number'|'tel'|'range'|'textarea'|'select'|'radio'|'checkbox'|'file'|'url'|undefined;
+    export type SweetAlertInputType =
+        | 'text' | 'email' | 'password' | 'number' | 'tel' | 'range' | 'textarea' | 'select' | 'radio' | 'checkbox'
+        | 'file' | 'url' | undefined;
 
-    export type SweetAlertInputOptions = { [inputValue: string]: string };
+    export interface SweetAlertInputOptions {
+        [inputValue: string]: string;
+    }
 
-    export type SweetAlertInputAttributes = { [attribute: string]: string };
+    export interface SweetAlertInputAttributes {
+        [attribute: string]: string;
+    }
 
     export interface SweetAlertOptions {
         /**
@@ -243,11 +250,12 @@ declare module 'sweetalert2' {
          *
          * @default null
          */
-        html?: string|JQuery;
+        html?: string | JQuery;
 
         /**
          * The type of the modal.
-         * SweetAlert2 comes with 5 built-in types which will show a corresponding icon animation: warning, error, success, info and question.
+         * SweetAlert2 comes with 5 built-in types which will show a corresponding icon animation: 'warning', 'error',
+         * 'success', 'info' and 'question'.
          * It can either be put in the array under the key "type" or passed as the third parameter of the function.
          *
          * @default null
@@ -262,7 +270,8 @@ declare module 'sweetalert2' {
         target?: string;
 
         /**
-         * Input field type, can be text, email, password, number, tel, range, textarea, select, radio, checkbox, file and url.
+         * Input field type, can be text, email, password, number, tel, range, textarea, select, radio, checkbox, file
+         * and url.
          *
          * @default null
          */
@@ -273,7 +282,7 @@ declare module 'sweetalert2' {
          *
          * @default '500px'
          */
-        width?: number|string;
+        width?: number | string;
 
         /**
          * Modal window padding.
@@ -294,14 +303,16 @@ declare module 'sweetalert2' {
          *
          * @default 'center'
          */
-        position?: 'top' | 'top-left' | 'top-right' | 'center' | 'center-left' | 'center-right' | 'bottom' | 'bottom-left' | 'bottom-right'
+        position?: | 'top' | 'top-left' | 'top-right'
+            | 'center' | 'center-left' | 'center-right'
+            | 'bottom' | 'bottom-left' | 'bottom-right';
 
         /**
          * Modal window grow direction
          *
          * @default false
          */
-        grow?: 'row' | 'column' | 'fullscreen' | boolean
+        grow?: 'row' | 'column' | 'fullscreen' | boolean;
 
         /**
          * A custom CSS class for the modal.
@@ -336,7 +347,7 @@ declare module 'sweetalert2' {
          *
          * @default true
          */
-        allowEscapeKey?: boolean
+        allowEscapeKey?: boolean;
 
         /**
          * If set to false, the user can't confirm the modal by pressing the Enter or Space keys,
@@ -537,7 +548,7 @@ declare module 'sweetalert2' {
          * If input parameter is set to "select" or "radio", you can provide options.
          * Object keys will represent options values, object values will represent options text values.
          */
-        inputOptions?: SweetAlertInputOptions|Promise<SweetAlertInputOptions>;
+        inputOptions?: SweetAlertInputOptions | Promise<SweetAlertInputOptions>;
 
         /**
          * Automatically remove whitespaces from both ends of a result string.
@@ -629,8 +640,12 @@ declare module 'sweetalert2' {
         onClose?: (modalElement: HTMLElement) => void;
 
         /**
-         * Determines whether dismissals (outside click, cancel button, close button, esc key) should reject, or resolve with an object of the format `{ dismiss: reason }`.
-         * Set it to `false` to get a cleaner control flow when using `await`, as explained here: https://github.com/limonte/sweetalert2/issues/485
+         * Determines whether dismissals (outside click, cancel button, close button, esc key) should reject, or resolve
+         * with an object of the format `{ dismiss: reason }`.
+         * Confirm-ed alerts will resolve too with an object of format `{ value: alertResult }`.
+         *
+         * Set it to `false` to get a cleaner control flow when using `await`:
+         * {@link https://github.com/limonte/sweetalert2/issues/485}
          *
          * @default true
          */
@@ -644,6 +659,8 @@ declare module 'sweetalert2' {
  * These interfaces aren't provided by SweetAlert2, but its definitions use them.
  * They will be merged with 'true' definitions.
  */
+
+// tslint:disable:no-empty-interface
 
 interface JQuery {
 }

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -212,6 +212,8 @@ declare module 'sweetalert2' {
         | 'text' | 'email' | 'password' | 'number' | 'tel' | 'range' | 'textarea' | 'select' | 'radio' | 'checkbox'
         | 'file' | 'url' | undefined;
 
+    export type SweetAlertDismissalReason = 'cancel' | 'close' | 'overlay' | 'esc' | 'timer';
+
     export interface SweetAlertInputOptions {
         [inputValue: string]: string;
     }
@@ -641,8 +643,8 @@ declare module 'sweetalert2' {
 
         /**
          * Determines whether dismissals (outside click, cancel button, close button, esc key) should reject, or resolve
-         * with an object of the format `{ dismiss: reason }`.
-         * Confirm-ed alerts will resolve too with an object of format `{ value: alertResult }`.
+         * with an object of the format `{ dismiss: SweetAlertDismissalReason }`.
+         * Confirm-ed alerts will resolve too with an object of format `{ value: any }`.
          *
          * Set it to `false` to get a cleaner control flow when using `await`:
          * {@link https://github.com/limonte/sweetalert2/issues/485}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,8 @@
+{
+    "defaultSeverity": "error",
+    "extends": ["tslint:recommended"],
+    "rules": {
+      "quotemark": false,
+      "interface-name": false
+    }
+}


### PR DESCRIPTION
It's time to be safer! :)

The PR consists of a few minor improvements ; most importantly, `sweetalert2.d.ts` will now be type-checked by TypeScript (meaning that invalid syntax or static typing mistakes will be caught before they are publicated to npm), and tslint will lint the file (I fixed the code style errors at the same time).

:warning: I didn't commited the package-lock.json. It's the very first time I try to use npm 5 over yarn and boom, I see that npm is still quite inconsitent regarding its own lockfile: https://github.com/npm/npm/issues/17979 / https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json
When I ran "npm i", npm ignored and then rewrote the package-lock.json, which should just not happen. So I didn't commited it since I don't really know how you want to keep it up to date, @limonte.