### PR TITLE
Return another promise within a resolve handler to capture entire async operation

### DIFF
--- a/config/utils.js
+++ b/config/utils.js
@@ -36,7 +36,7 @@ const packageRollup = (options) => {
     ]
   })
   .then((bundle) => {
-    bundle.generate({
+    return bundle.generate({
       format: options.format,
       banner: banner,
       name: classify(pack.name),


### PR DESCRIPTION
Like a month ago, there was an unhandled rejection coming from here, of a strange error. 

Didn't find out what the error was, and it's gone now, but still...

Chaining promises this way makes sure the error is bubbled up to somewhere it can be handled appropriately, in this case Gulp so it can fail the build and show us an error message with stack trace.

Watch out for when unhandled rejections will crash the process:

```
C:\Users\Matt\Documents\dev\sweetalert2>node -e "Promise.reject(new Error('foo'))
(node:14656) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: foo
(node:14656) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```