### PR TITLE
Add expectRejections parameter, defaulting to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Configuration
 | `showCloseButton`        | `false`               | Set to `true` to show close button in top right corner of the modal. |
 | `closeButtonAriaLabel`   | `'Close this dialog'` | Use this to change the `aria-label` for the close button. |
 | `showLoaderOnConfirm`    | `false`               | Set to `true` to disable buttons and show that something is loading. Use it in combination with the `preConfirm` parameter. |
-| `preConfirm`             | `null`                | Function to execute before confirm, should return Promise, see <a href="https://limonte.github.io/sweetalert2/#ajax-request">usage example</a>. |
+| `preConfirm`             | `null`                | Function to execute before confirm, may be async (Promise-returning) or sync, see <a href="https://limonte.github.io/sweetalert2/#ajax-request">usage example</a>. |
 | `imageUrl`               | `null`                | Add an image for the modal. Should contain a string with the path or URL to the image. |
 | `imageWidth`             | `null`                | If imageUrl is set, you can specify imageWidth to describes image width in px. |
 | `imageHeight`            | `null`                | Custom image height in px. |
@@ -205,7 +205,7 @@ Configuration
 | `inputOptions`           | `{}` or `Promise`     | If `input` parameter is set to `'select'` or `'radio'`, you can provide options. Object keys will represent options values, object values will represent options text values. |
 | `inputAutoTrim`          | `true`                | Automatically remove whitespaces from both ends of a result string. Set this parameter to `false` to disable auto-trimming. |
 | `inputAttributes`        | `{}`                  | HTML input attributes (e.g. `'min'`, `'max'`, `'autocomplete'`, `'accept'`), that are added to the input field. Object keys will represent attributes names, object values will represent attributes values. |
-| `inputValidator`         | `null`                | Validator for input field, should return Promise, see <a href="https://limonte.github.io/sweetalert2/#select-box">usage example</a>. |
+| `inputValidator`         | `null`                | Validator for input field, may be async (Promise-returning) or sync, see <a href="https://limonte.github.io/sweetalert2/#input-select">usage example</a>. |
 | `inputClass`             | `null`                | A custom CSS class for the input field. |
 | `progressSteps`          | `[]`                  | Progress steps, useful for modal queues, see <a href="https://limonte.github.io/sweetalert2/#chaining-modals">usage example</a>. |
 | `currentProgressStep`    | `null`                | Current active progress step. The default is `swal.getQueueStep()`. |
@@ -214,6 +214,7 @@ Configuration
 | `onOpen`                 | `null`                | Function to run when modal opens, provides modal DOM element as the first argument. |
 | `onClose`                | `null`                | Function to run when modal closes, provides modal DOM element as the first argument. |
 | `useRejections`          | `false`               | **Deprecated and will be removed in the next major release.** Determines whether dismissals (outside click, cancel button, close button, <kdb>Esc</kbd> key, timer) should resolve with an object of the format `{ dismiss: reason }` or reject the promise. |
+| `expectRejections`       | `false`               | **Deprecated and will be removed in the next major release.** Determines whether given `inputValidator` and `preConfirm` functions should be expected to to signal validation errors by rejecting, or by their respective means (see documentation for each option). |
 
 You can redefine default params by using `swal.setDefaults(customParams)` where `customParams` is an object.
 

--- a/index.html
+++ b/index.html
@@ -310,10 +310,9 @@ swal({
     <span class="tag">return new</span> <span class="func">Promise</span>(<span class="func"><i>function</i></span> (resolve, reject) {
       <span class="func">setTimeout</span>(<span class="func">function</span>() {
         <span class="tag">if</span> (email === <span class="str">'taken@example.com'</span>) {
-          reject(<span class="str">'This email is already taken.'</span>)
-        } else {
-          resolve()
+          swal.showValidationError(<span class="str">'This email is already taken.'</span>)
         }
+        resolve()
       }, <span class="val">2000</span>)
     })
   },
@@ -378,13 +377,10 @@ swal.queue([{
     <span class="str">'via AJAX request'</span>,
   showLoaderOnConfirm: <span class="val">true</span>,
   preConfirm: <span class="func"><i>function</i></span> () {
-    <span class="tag">return new</span> <span class="func">Promise</span>(<span class="func"><i>function</i></span> (resolve) {
-      $.get(<span class="str">'https://api.ipify.org?format=json'</span>)
-        .done(<span class="func"><i>function</i></span> (data) {
-          swal.insertQueueStep(data.ip)
-          resolve()
-        })
-    })
+    <span class="tag">return</span> $.get(<span class="str">'https://api.ipify.org?format=json'</span>)
+      .then(<span class="func"><i>function</i></span> (data) {
+        swal.insertQueueStep(data.ip)
+      })
   }
 }])</pre>
     </li>
@@ -641,7 +637,7 @@ swal.queue([{
       <tr id="pre-confirm">
         <td><b>preConfirm</b></td>
         <td><i>null</i></td>
-        <td>Function to execute before confirm, should return Promise, see <a href="#ajax-request">usage example</a>.</td>
+        <td>Function to execute before confirm, may be async (Promise-returning) or sync, see <a href="#ajax-request">usage example</a>.</td>
       </tr>
       <tr id="image">
         <td><b>imageUrl</b></td>
@@ -696,7 +692,7 @@ swal.queue([{
       <tr id="input-validator">
         <td><b>inputValidator</b></td>
         <td><i>null</i></td>
-        <td>Validator for input field, should return Promise, see <a href="#select-box">usage example</a>.</td>
+        <td>Validator for input field, may be async (Promise-returning) or sync, see <a href="#input-select">usage example</a>.</td>
       </tr>
       <tr id="input-class">
         <td><b>inputClass</b></td>
@@ -737,6 +733,11 @@ swal.queue([{
         <td><b>useRejections</b></td>
         <td><i>false</i></td>
         <td><strong>Deprecated and will be removed in the next major release.</strong> Determines whether dismissals (outside click, cancel button, close button, Esc key, timer) should resolve with an object of the format <strong>{ dismiss: reason }</strong> or reject the promise.</td>
+      </tr>
+      <tr>
+        <td><b>expectRejections</b></td>
+        <td><i>false</i></td>
+        <td><strong>Deprecated and will be removed in the next major release.</strong> Determines whether given <strong>inputValidator</strong> and <strong>preConfirm</strong> functions should be expected to to signal validation errors by rejecting, or by their respective means (see documentation for each option). </td>
       </tr>
     </table>
 
@@ -851,13 +852,7 @@ swal({
   inputPlaceholder: <span class="str">'Enter your name or nickname'</span>,
   showCancelButton: <span class="val">true</span>,
   inputValidator: <span class="func"><i>function</i></span> (value) {
-    <span class="tag">return new</span> <span class="func">Promise</span>(<span class="func"><i>function</i></span> (resolve, reject) {
-      <span class="tag">if</span> (value) {
-        resolve()
-      } <span class="tag">else</span> {
-        reject(<span class="str">'You need to write something!'</span>)
-      }
-    })
+    <span class="tag">return</span> !value && <span class="str">'You need to write something!'</span>
   }
 }).then(<span class="func"><i>function</i></span> (name) {
   swal({
@@ -965,7 +960,7 @@ swal({
       <span class="tag">if</span> (value === <span class="str">'UKR'</span>) {
         resolve()
       } <span class="tag">else</span> {
-        reject(<span class="str">'You need to select Ukraine :)'</span>)
+        resolve(<span class="str">'You need to select Ukraine :)'</span>)
       }
     })
   }
@@ -999,14 +994,8 @@ swal({
   title: <span class="str">'Select color'</span>,
   input: <span class="str">'radio'</span>,
   inputOptions: inputOptions,
-  inputValidator: <span class="func"><i>function</i></span> (result) {
-    <span class="tag">return new</span> <span class="func">Promise</span>(<span class="func"><i>function</i></span> (resolve, reject) {
-      <span class="tag">if</span> (result) {
-        resolve()
-      } <span class="tag">else</span> {
-        reject(<span class="str">'You need to select something!'</span>)
-      }
-    })
+  inputValidator: <span class="func"><i>function</i></span> (value) {
+    <span class="tag">return</span> !value && <span class="str">'You need to write something!'</span>
   }
 }).then(<span class="func"><i>function</i></span> (result) {
   swal({
@@ -1031,13 +1020,7 @@ swal({
   confirmButtonText:
     <span class="str">'Continue &lt;i class="fa fa-arrow-right&gt;&lt;/i&gt;'</span>,
   inputValidator: <span class="func"><i>function</i></span> (result) {
-    <span class="tag">return new</span> <span class="func">Promise</span>(<span class="func"><i>function</i></span> (resolve, reject) {
-      <span class="tag">if</span> (result) {
-        resolve()
-      } <span class="tag">else</span> {
-        reject(<span class="str">'You need to agree with T&amp;C'</span>)
-      }
-    })
+    <span class="tag">return</span> !result && <span class="str">'You need to agree with T&amp;C'</span>
   }
 }).then(<span class="func"><i>function</i></span> (result) {
   swal({
@@ -1098,7 +1081,7 @@ swal({
 
   <p id="multiple-inputs">
     Multiple inputs aren't supported, you can achieve them by using <strong>html</strong> and <strong>preConfirm</strong> parameters.<br>
-    Inside the <strong>preConfirm()</strong> function you can pass the custom result to the <strong>resolve()</strong> function as a parameter:
+    Inside the <strong>preConfirm()</strong> function you can return (or, if async, resolve with) the custom result:
   </p>
   <table class="modal-input-types">
     <tr id="multiple-inputs">
@@ -1112,12 +1095,10 @@ swal({
     <span class="str">'&lt;input id="swal-input2" class="swal2-input"&gt;'</span>,
   focusConfirm: <span class="val">false</span>,
   preConfirm: <span class="func"><i>function</i></span> () {
-    <span class="tag">return new</span> <span class="func">Promise</span>(<span class="func"><i>function</i></span> (resolve) {
-      resolve([
-        $(<span class="str">'#swal-input1'</span>).val(),
-        $(<span class="str">'#swal-input2'</span>).val()
-      ])
-    })
+    <span class="tag">return</span> [
+      $(<span class="str">'#swal-input1'</span>).val(),
+      $(<span class="str">'#swal-input2'</span>).val()
+    ]
   }
 }).then(<span class="func"><i>function</i></span> (result) {
   swal(JSON.stringify(result))
@@ -1507,13 +1488,7 @@ swal({
       inputPlaceholder: 'Enter your name or nickname',
       showCancelButton: true,
       inputValidator: function (value) {
-        return new Promise(function (resolve, reject) {
-          if (value) {
-            resolve()
-          } else {
-            reject('You need to write something!')
-          }
-        })
+        return !value && 'You need to write something!'
       }
     }).then(function (name) {
       swal({
@@ -1599,7 +1574,7 @@ swal({
           if (value === 'UKR') {
             resolve()
           } else {
-            reject('You need to select Ukraine :)')
+            resolve('You need to select Ukraine :)')
           }
         })
       }
@@ -1627,13 +1602,7 @@ swal({
       input: 'radio',
       inputOptions: inputOptionsPromise,
       inputValidator: function (value) {
-        return new Promise(function (resolve, reject) {
-          if (value) {
-            resolve()
-          } else {
-            reject('You need to choose something!')
-          }
-        })
+        return !value && 'You need to choose something!'
       }
     }).then(function (result) {
       swal({
@@ -1651,13 +1620,7 @@ swal({
       inputPlaceholder: 'I agree with the terms and conditions',
       confirmButtonText: 'Continue <i class="fa fa-arrow-right" style="margin-left: 10px"></i>',
       inputValidator: function (result) {
-        return new Promise(function (resolve, reject) {
-          if (result) {
-            resolve()
-          } else {
-            reject('To continue you need to agree with T&amp;C')
-          }
-        })
+        return !result && 'To continue you need to agree with T&amp;C'
       }
     }).then(function () {
       swal({
@@ -1710,12 +1673,10 @@ swal({
         '<input id="swal-input2" class="swal2-input" placeholder="second input field">',
       focusConfirm: false,
       preConfirm: function () {
-        return new Promise(function (resolve) {
-          resolve([
-            $('#swal-input1').val(),
-            $('#swal-input2').val()
-          ])
-        })
+        return [
+          $('#swal-input1').val(),
+          $('#swal-input2').val()
+        ]
       }
     }).then(function (result) {
       swal(JSON.stringify(result))
@@ -1734,10 +1695,9 @@ swal({
         return new Promise(function (resolve, reject) {
           setTimeout(function () {
             if (email === 'taken@example.com') {
-              reject('This email is already taken.')
-            } else {
-              resolve()
+              swal.showValidationError('This email is already taken.')
             }
+            resolve()
           }, 2000)
         })
       },
@@ -1786,13 +1746,10 @@ swal({
         currentProgressStep: 0,
         showLoaderOnConfirm: true,
         preConfirm: function () {
-          return new Promise(function (resolve) {
-            $.get('https://api.ipify.org?format=json')
-              .done(function (data) {
-                swal.insertQueueStep(data.ip)
-                resolve()
-              })
-          })
+          return $.get('https://api.ipify.org?format=json')
+            .then(function (data) {
+              swal.insertQueueStep(data.ip)
+            })
         }
       }
     ]).catch(swal.noop)

--- a/qunit/deprecated.js
+++ b/qunit/deprecated.js
@@ -172,3 +172,28 @@ QUnit.test('input checkbox', function (assert) {
   checkbox.prop('checked', true)
   swal.clickConfirm()
 })
+
+QUnit.test('validation error /w expectRejections: true', function (assert) {
+  const done = assert.async()
+  const inputValidator = (value) => !value ? Promise.reject('no falsy values') : Promise.resolve()
+
+  swal({input: 'text', animation: false, inputValidator, expectRejections: true})
+  assert.ok($('.swal2-validationerror').is(':hidden'))
+  setTimeout(function () {
+    const initialModalHeight = $('.swal2-modal').outerHeight()
+
+    swal.clickConfirm()
+    setTimeout(function () {
+      assert.ok($('.swal2-validationerror').is(':visible'))
+      assert.equal($('.swal2-validationerror').text(), 'no falsy values')
+      assert.ok($('.swal2-input').attr('aria-invalid'))
+      assert.ok($('.swal2-modal').outerHeight() > initialModalHeight)
+
+      $('.swal2-input').val('blah-blah').trigger('input')
+      assert.ok($('.swal2-validationerror').is(':hidden'))
+      assert.notOk($('.swal2-input').attr('aria-invalid'))
+      assert.ok($('.swal2-modal').outerHeight() === initialModalHeight)
+      done()
+    })
+  }, 60)
+})

--- a/qunit/tests.js
+++ b/qunit/tests.js
@@ -155,8 +155,9 @@ QUnit.test('input text', function (assert) {
 
 QUnit.test('validation error', function (assert) {
   const done = assert.async()
+  const inputValidator = (value) => Promise.resolve(!value && 'no falsy values')
 
-  swal({input: 'email', animation: false})
+  swal({input: 'text', animation: false, inputValidator})
   assert.ok($('.swal2-validationerror').is(':hidden'))
   setTimeout(function () {
     const initialModalHeight = $('.swal2-modal').outerHeight()
@@ -164,6 +165,7 @@ QUnit.test('validation error', function (assert) {
     swal.clickConfirm()
     setTimeout(function () {
       assert.ok($('.swal2-validationerror').is(':visible'))
+      assert.equal($('.swal2-validationerror').text(), 'no falsy values')
       assert.ok($('.swal2-input').attr('aria-invalid'))
       assert.ok($('.swal2-modal').outerHeight() > initialModalHeight)
 

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -514,7 +514,7 @@ const sweetAlert = (...args) => {
         params.preConfirm(value, params.extraParams).then(
           (preConfirmValue) => {
             sweetAlert.closePopup(params.onClose)
-            resolve(preConfirmValue || value)
+            succeedWith(preConfirmValue || value)
           },
           (error) => {
             sweetAlert.hideLoading()

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -522,10 +522,10 @@ const sweetAlert = (...args) => {
               sweetAlert.closePopup(params.onClose)
               succeedWith(preConfirmValue || value)
             },
-            (error) => {
+            (validationError) => {
               sweetAlert.hideLoading()
-              if (error) {
-                sweetAlert.showValidationError(error)
+              if (validationError) {
+                sweetAlert.showValidationError(validationError)
               }
             }
           )
@@ -599,11 +599,11 @@ const sweetAlert = (...args) => {
                       sweetAlert.enableInput()
                       confirm(inputValue)
                     },
-                    (error) => {
+                    (validationError) => {
                       sweetAlert.enableButtons()
                       sweetAlert.enableInput()
-                      if (error) {
-                        sweetAlert.showValidationError(error)
+                      if (validationError) {
+                        sweetAlert.showValidationError(validationError)
                       }
                     }
                   )
@@ -1108,9 +1108,9 @@ sweetAlert.queue = (steps) => {
             queueResult.push(result)
             step(i + 1, callback)
           },
-          (dismiss) => {
+          (error) => {
             resetQueue()
-            reject(dismiss)
+            reject(error)
           }
         )
       } else {

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -554,7 +554,9 @@ const sweetAlert = (...args) => {
         } else {
           preConfirmPromise.then(
             (preConfirmValue) => {
-              if (!dom.isVisible(dom.getValidationError())) {
+              if (dom.isVisible(dom.getValidationError())) {
+                sweetAlert.hideLoading()
+              } else {
                 succeedWith(preConfirmValue || value)
               }
             },

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -404,7 +404,7 @@ const sweetAlert = (...args) => {
       params.extraParams = args[0].extraParams
 
       if (params.input === 'email' && params.inputValidator === null) {
-        params.inputValidator = (email) => {
+        const inputValidator = (email) => {
           return new Promise((resolve, reject) => {
             const emailRegex = /^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/
             if (emailRegex.test(email)) {
@@ -414,10 +414,11 @@ const sweetAlert = (...args) => {
             }
           })
         }
+        params.inputValidator = params.expectRejections ? inputValidator : sweetAlert.adaptInputValidator(inputValidator)
       }
 
       if (params.input === 'url' && params.inputValidator === null) {
-        params.inputValidator = (url) => {
+        const inputValidator = (url) => {
           return new Promise((resolve, reject) => {
             // taken from https://stackoverflow.com/a/3809435/1331425
             const urlRegex = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)$/
@@ -428,6 +429,7 @@ const sweetAlert = (...args) => {
             }
           })
         }
+        params.inputValidator = params.expectRejections ? inputValidator : sweetAlert.adaptInputValidator(inputValidator)
       }
       break
 
@@ -1263,6 +1265,16 @@ sweetAlert.setDefaults = (userParams) => {
  */
 sweetAlert.resetDefaults = () => {
   popupParams = Object.assign({}, defaultParams)
+}
+
+/**
+ * Adapt a legacy inputValidator for use with expectRejections=false
+ */
+sweetAlert.adaptInputValidator = (legacyValidator) => {
+  return function adaptedInputValidator (inputValue, extraParams) {
+    return legacyValidator.call(this, inputValue, extraParams)
+      .then(() => undefined, validationError => validationError)
+  }
 }
 
 sweetAlert.noop = () => { }

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -528,7 +528,7 @@ const sweetAlert = (...args) => {
       }
 
       if (params.preConfirm) {
-        const preConfirmPromise = params.preConfirm(value, params.extraParams)
+        const preConfirmPromise = Promise.resolve().then(() => params.preConfirm(value, params.extraParams))
         if (params.expectRejections) {
           preConfirmPromise.then(
             (preConfirmValue) => succeedWith(preConfirmValue || value),
@@ -597,7 +597,7 @@ const sweetAlert = (...args) => {
 
               if (params.inputValidator) {
                 sweetAlert.disableInput()
-                const validationPromise = params.inputValidator(inputValue, params.extraParams)
+                const validationPromise = Promise.resolve().then(() => params.inputValidator(inputValue, params.extraParams))
                 if (params.expectRejections) {
                   validationPromise.then(
                     () => {

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -442,15 +442,15 @@ const sweetAlert = (...args) => {
   const popup = dom.getPopup()
 
   return new Promise((resolve, reject) => {
+    // functions to handle all resolving/rejecting/settling
+    const succeedWith = value => params.useRejections ? resolve(value) : resolve({value})
+    const dismissWith = dismiss => params.useRejections ? reject(dismiss) : resolve({dismiss})
+
     // Close on timer
     if (params.timer) {
       popup.timeout = setTimeout(() => {
         sweetAlert.closePopup(params.onClose)
-        if (params.useRejections) {
-          reject('timer')
-        } else {
-          resolve({dismiss: 'timer'})
-        }
+        dismissWith('timer')
       }, params.timer)
     }
 
@@ -525,11 +525,7 @@ const sweetAlert = (...args) => {
         )
       } else {
         sweetAlert.closePopup(params.onClose)
-        if (params.useRejections) {
-          resolve(value)
-        } else {
-          resolve({value: value})
-        }
+        succeedWith(value)
       }
     }
 
@@ -605,11 +601,7 @@ const sweetAlert = (...args) => {
           } else if (targetedCancel && sweetAlert.isVisible()) {
             sweetAlert.disableButtons()
             sweetAlert.closePopup(params.onClose)
-            if (params.useRejections) {
-              reject('cancel')
-            } else {
-              resolve({dismiss: 'cancel'})
-            }
+            dismissWith('cancel')
           }
           break
         default:
@@ -627,11 +619,7 @@ const sweetAlert = (...args) => {
     // Closing popup by close button
     dom.getCloseButton().onclick = () => {
       sweetAlert.closePopup(params.onClose)
-      if (params.useRejections) {
-        reject('close')
-      } else {
-        resolve({dismiss: 'close'})
-      }
+      dismissWith('close')
     }
 
     if (params.toast) {
@@ -642,11 +630,7 @@ const sweetAlert = (...args) => {
         }
         if (params.allowOutsideClick) {
           sweetAlert.closePopup(params.onClose)
-          if (params.useRejections) {
-            reject('overlay')
-          } else {
-            resolve({dismiss: 'overlay'})
-          }
+          dismissWith('overlay')
         }
       }
     } else {
@@ -656,11 +640,7 @@ const sweetAlert = (...args) => {
         }
         if (params.allowOutsideClick) {
           sweetAlert.closePopup(params.onClose)
-          if (params.useRejections) {
-            reject('overlay')
-          } else {
-            resolve({dismiss: 'overlay'})
-          }
+          dismissWith('overlay')
         }
       }
     }
@@ -750,11 +730,7 @@ const sweetAlert = (...args) => {
       // ESC
       } else if ((e.key === 'Escape' || e.key === 'Esc') && params.allowEscapeKey === true) {
         sweetAlert.closePopup(params.onClose)
-        if (params.useRejections) {
-          reject('esc')
-        } else {
-          resolve({dismiss: 'esc'})
-        }
+        dismissWith('esc')
       }
     }
 

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -541,7 +541,11 @@ const sweetAlert = (...args) => {
           )
         } else {
           preConfirmPromise.then(
-            (preConfirmValue) => succeedWith(preConfirmValue || value),
+            (preConfirmValue) => {
+              if (!dom.isVisible(dom.getValidationError())) {
+                succeedWith(preConfirmValue || value)
+              }
+            },
             (error) => errorWith(error)
           )
         }

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -443,8 +443,22 @@ const sweetAlert = (...args) => {
 
   return new Promise((resolve, reject) => {
     // functions to handle all resolving/rejecting/settling
-    const succeedWith = value => params.useRejections ? resolve(value) : resolve({value})
-    const dismissWith = dismiss => params.useRejections ? reject(dismiss) : resolve({dismiss})
+    const succeedWith = (value) => {
+      sweetAlert.closePopup(params.onClose)
+      if (params.useRejections) {
+        resolve(value)
+      } else {
+        resolve({value})
+      }
+    }
+    const dismissWith = (dismiss) => {
+      sweetAlert.closePopup(params.onClose)
+      if (params.useRejections) {
+        reject(dismiss)
+      } else {
+        resolve({dismiss})
+      }
+    }
     const errorWith = error => {
       sweetAlert.closePopup(params.onClose)
       reject(error)
@@ -452,10 +466,7 @@ const sweetAlert = (...args) => {
 
     // Close on timer
     if (params.timer) {
-      popup.timeout = setTimeout(() => {
-        sweetAlert.closePopup(params.onClose)
-        dismissWith('timer')
-      }, params.timer)
+      popup.timeout = setTimeout(() => dismissWith('timer'), params.timer)
     }
 
     // Get input element by specified type or, if type isn't specified, by params.input
@@ -518,10 +529,7 @@ const sweetAlert = (...args) => {
         const preConfirmPromise = params.preConfirm(value, params.extraParams)
         if (params.expectRejections) {
           preConfirmPromise.then(
-            (preConfirmValue) => {
-              sweetAlert.closePopup(params.onClose)
-              succeedWith(preConfirmValue || value)
-            },
+            (preConfirmValue) => succeedWith(preConfirmValue || value),
             (validationError) => {
               sweetAlert.hideLoading()
               if (validationError) {
@@ -531,15 +539,11 @@ const sweetAlert = (...args) => {
           )
         } else {
           preConfirmPromise.then(
-            (preConfirmValue) => {
-              sweetAlert.closePopup(params.onClose)
-              succeedWith(preConfirmValue || value)
-            },
+            (preConfirmValue) => succeedWith(preConfirmValue || value),
             (error) => errorWith(error)
           )
         }
       } else {
-        sweetAlert.closePopup(params.onClose)
         succeedWith(value)
       }
     }
@@ -631,7 +635,6 @@ const sweetAlert = (...args) => {
           // Clicked 'cancel'
           } else if (targetedCancel && sweetAlert.isVisible()) {
             sweetAlert.disableButtons()
-            sweetAlert.closePopup(params.onClose)
             dismissWith('cancel')
           }
           break
@@ -649,7 +652,6 @@ const sweetAlert = (...args) => {
 
     // Closing popup by close button
     dom.getCloseButton().onclick = () => {
-      sweetAlert.closePopup(params.onClose)
       dismissWith('close')
     }
 
@@ -670,7 +672,6 @@ const sweetAlert = (...args) => {
           return
         }
         if (params.allowOutsideClick) {
-          sweetAlert.closePopup(params.onClose)
           dismissWith('overlay')
         }
       }
@@ -760,7 +761,6 @@ const sweetAlert = (...args) => {
 
       // ESC
       } else if ((e.key === 'Escape' || e.key === 'Esc') && params.allowEscapeKey === true) {
-        sweetAlert.closePopup(params.onClose)
         dismissWith('esc')
       }
     }

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -55,5 +55,6 @@ export default {
   onBeforeOpen: null,
   onOpen: null,
   onClose: null,
-  useRejections: false
+  useRejections: false,
+  expectRejections: false
 }

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -60,5 +60,6 @@ export default {
 }
 
 export const deprecatedParams = [
-  'useRejections'
+  'useRejections',
+  'expectRejections'
 ]

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -511,7 +511,7 @@ declare module 'sweetalert2' {
          *
          * @default null
          */
-        preConfirm?: (inputValue: any) => Promise<any>;
+        preConfirm?: (inputValue: any) => Promise<any | void> | any | void;
 
         /**
          * Add a customized icon for the modal. Should contain a string with the path or URL to the image.
@@ -604,7 +604,7 @@ declare module 'sweetalert2' {
          *
          * @default null
          */
-        inputValidator?: (result: any) => Promise<void>;
+        inputValidator?: (inputValue: any) => Promise<string | null> | string | null;
 
         /**
          * A custom CSS class for the input field.

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -497,7 +497,7 @@ declare module 'sweetalert2' {
         showLoaderOnConfirm?: boolean;
 
         /**
-         * Function to execute before confirm, should return Promise.
+         * Function to execute before confirm, may be async (Promise-returning) or sync.
          *
          * ex.
          *   swal({
@@ -506,7 +506,7 @@ declare module 'sweetalert2' {
          *      '<input id="swal-input1" class="swal2-input">' +
          *      '<input id="swal-input2" class="swal2-input">',
          *    focusConfirm: false,
-         *    preConfirm: () => Promise.resolve([$('#swal-input1').val(), $('#swal-input2').val()])
+         *    preConfirm: () => [$('#swal-input1').val(), $('#swal-input2').val()]
          *  }).then(result => swal(JSON.stringify(result));
          *
          * @default null
@@ -593,15 +593,13 @@ declare module 'sweetalert2' {
         inputAttributes?: SweetAlertInputAttributes;
 
         /**
-         * Validator for input field, should return a Promise.
+         * Validator for input field, may be async (Promise-returning) or sync.
          *
          * ex.
          *   swal({
          *     title: 'Select color',
          *     input: 'radio',
-         *     inputValidator: result => new Promise((resolve, reject) => {
-         *       result ? resolve() : reject('You need to select something!');
-         *     })
+         *     inputValidator: result => !result && 'You need to select something!'
          *   })
          *
          * @default null
@@ -665,6 +663,15 @@ declare module 'sweetalert2' {
          * @deprecated
          */
         useRejections?: boolean;
+
+        /**
+         * Determines whether given `inputValidator` and `preConfirm` functions should be expected to to signal
+         * validation errors by rejecting, or by their respective means (see documentation for each option).
+         *
+         * @default false
+         * @deprecated
+         */
+        expectRejections?: boolean;
     }
 
     export default swal;


### PR DESCRIPTION
Resolves Issue #485 finally

1. Rebased & updated my work from #674 (please re-review changes)
2. Added "Support for sync `inputValidators` and `preConfirms`"
3. Made a change to "Succeed after preConfirm finishes only if no validation error is shown (applies only to expectRejections: false)" (as per discussion with @toverux in PR #647)

We still need (before or after merging):

~~1. Deprecation warning. Pending updates from PR #699.~~
~~2. Tests for `preConfirm` param. There never were any.~~
~~3. Documentation updates.~~