### PR TITLE
Restore TypeScript 2.0 compatibility in the declaration file

### DIFF
--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -209,8 +209,8 @@ declare module 'sweetalert2' {
     export type SweetAlertType = 'success' | 'error' | 'warning' | 'info' | 'question' | undefined;
 
     export type SweetAlertInputType =
-        | 'text' | 'email' | 'password' | 'number' | 'tel' | 'range' | 'textarea' | 'select' | 'radio' | 'checkbox'
-        | 'file' | 'url' | undefined;
+        'text' | 'email' | 'password' | 'number' | 'tel' | 'range' | 'textarea' | 'select' | 'radio' | 'checkbox' |
+        'file' | 'url' | undefined;
 
     export type SweetAlertDismissalReason = 'cancel' | 'close' | 'overlay' | 'esc' | 'timer';
 
@@ -321,9 +321,10 @@ declare module 'sweetalert2' {
          *
          * @default 'center'
          */
-        position?: | 'top' | 'top-left' | 'top-right'
-            | 'center' | 'center-left' | 'center-right'
-            | 'bottom' | 'bottom-left' | 'bottom-right';
+        position?:
+            'top' | 'top-left' | 'top-right' |
+            'center' | 'center-left' | 'center-right' |
+            'bottom' | 'bottom-left' | 'bottom-right';
 
         /**
          * Modal window grow direction


### PR DESCRIPTION
An user of NgSweetAlert2 reported an incompatibility with TypeScript ~2.0.0 in SweetAlert's declaration file: https://github.com/toverux/ngsweetalert2/issues/30
We've recently added leading pipes for type unions (these are like trailing commas), but that syntax was added in TypeScript 2.1. Fortunately, there are few TypeScript 2.0 setups nowadays.