### PR TITLE
Add .swal2-toast-shown to ignore list for default overflow rules

### DIFF
--- a/src/sweetalert2.scss
+++ b/src/sweetalert2.scss
@@ -6,7 +6,10 @@
 
 body {
   &.swal2-shown {
-    &:not(.swal2-no-backdrop) {
+    @include not(
+      '.swal2-no-backdrop',
+      '.swal2-toast-shown'
+    ) {
       overflow-y: hidden;
     }
   }


### PR DESCRIPTION
Noticed a small issue where toasts were not defaulting to allowing document scroll.