### PR TITLE
Use arrow functions for demo examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ swal({
   showCancelButton: true,
   confirmButtonText: 'Yes, delete it!',
   cancelButtonText: 'No, keep it'
-}).then(function(result) {
+}).then((result) => {
   if (result.value) {
     swal(
       'Deleted!',

--- a/assets/example.js
+++ b/assets/example.js
@@ -1,9 +1,9 @@
 /* global XMLHttpRequest */
 function makeApiRequest (endpoint) {
-  return new Promise(function (resolve, reject) {
+  return new Promise((resolve, reject) => {
     var xhr = new XMLHttpRequest()
     xhr.open('GET', endpoint)
-    xhr.onload = function () {
+    xhr.onload = () => {
       if (xhr.status === 200) {
         resolve(JSON.parse(xhr.responseText))
       } else {
@@ -18,16 +18,16 @@ var stats = {}
 
 // latest release
 makeApiRequest('https://api.github.com/repos/limonte/sweetalert2/releases/latest').then(
-  function (response) {
+  (response) => {
     stats.latestRelease = response.tag_name
     showStats()
   },
-  function () {}
+  () => {}
 )
 
 // recent activity
 makeApiRequest('https://api.github.com/repos/limonte/sweetalert2/commits').then(
-  function (response) {
+  (response) => {
     var recentActivity = response[0].commit.author.date
     recentActivity = new Date(recentActivity)
     var today = new Date()
@@ -40,16 +40,16 @@ makeApiRequest('https://api.github.com/repos/limonte/sweetalert2/commits').then(
     stats.recentActivity = recentActivity
     showStats()
   },
-  function () {}
+  () => {}
 )
 
 // number of downloads last month
 makeApiRequest('https://api.npmjs.org/downloads/point/last-month/sweetalert2').then(
-  function (response) {
+  (response) => {
     stats.downloadsLastMonth = response.downloads.toLocaleString()
     showStats()
   },
-  function () {}
+  () => {}
 )
 
 function showStats () {

--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@ swal({
   confirmButtonColor: <span class="str">'#3085d6'</span>,
   cancelButtonColor: <span class="str">'#d33'</span>,
   confirmButtonText: <span class="str">'Yes, delete it!'</span>
-}).<span class="tag">then</span>(<span class="func"><i>function</i></span> (result) {
+}).<span class="tag">then</span>((result) => {
   <span class="tag">if</span> (result.value) {
     swal(
       <span class="str">'Deleted!'</span>,
@@ -222,7 +222,7 @@ swal({
   confirmButtonClass: <span class="str">'btn btn-success'</span>,
   cancelButtonClass: <span class="str">'btn btn-danger'</span>,
   buttonsStyling: <span class="val">false</span>
-}).<span class="tag">then</span>(<span class="func"><i>function</i></span> (result) {
+}).<span class="tag">then</span>((result) => {
   <span class="tag">if</span> (result.value) {
     swal(
       <span class="str">'Deleted!'</span>,
@@ -282,10 +282,10 @@ swal({
   title: <span class="str">'Auto close alert!'</span>,
   text: <span class="str">'I will close in 5 seconds.'</span>,
   timer: <span class="val">5000</span>,
-  onOpen: <span class="func"><i>function</i></span> () => {
+  onOpen: () => {
     swal.showLoading()
   }
-}).<span class="tag">then</span>(<span class="func"><i>function</i></span> (result) {
+}).<span class="tag">then</span>((result) => {
   <span class="tag">if</span> (result.dismiss === <span class="str">'timer'</span>) {
     console.log(<span class="str">'I was closed by the timer'</span>)
   }
@@ -304,9 +304,9 @@ swal({
   showCancelButton: <span class="val">true</span>,
   confirmButtonText: <span class="str">'Submit'</span>,
   showLoaderOnConfirm: <span class="val">true</span>,
-  preConfirm: <span class="func"><i>function</i></span> (email) => {
-    <span class="tag">return new</span> <span class="func">Promise</span>(<span class="func"><i>function</i></span> (resolve) => {
-      <span class="func">setTimeout</span>(<span class="func"><i>function</i></span> () {
+  preConfirm: (email) => {
+    <span class="tag">return new</span> <span class="func">Promise</span>((resolve) => {
+      <span class="func">setTimeout</span>(() => {
         <span class="tag">if</span> (email === <span class="str">'taken@example.com'</span>) {
           swal.showValidationError(
             <span class="str">'This email is already taken.'</span>
@@ -317,7 +317,7 @@ swal({
     })
   },
   allowOutsideClick: <span class="val">false</span>
-}).<span class="tag">then</span>(<span class="func"><i>function</i></span> (result) {
+}).<span class="tag">then</span>((result) => {
   <span class="tag">if</span> (result.value) {
     swal({
       type: <span class="str">'success'</span>,
@@ -350,7 +350,7 @@ swal.setDefaults({
   <span class="str">'Question 3'</span>
 ]
 
-swal.queue(steps).<span class="tag">then</span>(<span class="func"><i>function</i></span> (result) {
+swal.queue(steps).<span class="tag">then</span>((result) => {
   swal.resetDefaults()
 
   <span class="tag">if</span> (result.value) {
@@ -381,9 +381,9 @@ swal.queue([{
     <span class="str">'Your public IP will be received '</span> +
     <span class="str">'via AJAX request'</span>,
   showLoaderOnConfirm: <span class="val">true</span>,
-  preConfirm: <span class="func"><i>function</i></span> () {
-    <span class="tag">return new</span> <span class="func">Promise</span>(<span class="func"><i>function</i></span> (resolve) {
-      <span class="tag">return</span> $.get(ipAPI).<span class="tag">then</span>(<span class="func"><i>function</i></span> (data) {
+  preConfirm: () => {
+    <span class="tag">return new</span> <span class="func">Promise</span>((resolve) => {
+      <span class="tag">return</span> $.get(ipAPI).<span class="tag">then</span>((data) => {
         swal.insertQueueStep(data.ip)
       })
     }}
@@ -846,7 +846,7 @@ swal.queue([{
   input: <span class="str">'text'</span>,
   inputPlaceholder: <span class="str">'Enter your name or nickname'</span>,
   showCancelButton: <span class="val">true</span>,
-  inputValidator: <span class="func"><i>function</i></span> (value) {
+  inputValidator: (value) => {
     <span class="tag">return</span> !value <span class="val">&&</span> <span class="str">'You need to write something!'</span>
   }
 })
@@ -944,8 +944,8 @@ swal.queue([{
   },
   inputPlaceholder: <span class="str">'Select country'</span>,
   showCancelButton: <span class="val">true</span>,
-  inputValidator: <span class="func"><i>function</i></span> (value) {
-    <span class="tag">return new</span> <span class="func">Promise</span>(<span class="func"><i>function</i></span> (resolve) {
+  inputValidator: (value) => {
+    <span class="tag">return new</span> <span class="func">Promise</span>((resolve) => {
       <span class="tag">if</span> (value === <span class="str">'UKR'</span>) {
         resolve()
       } <span class="tag">else</span> {
@@ -967,8 +967,8 @@ swal.queue([{
       <td>
         <pre>
 <span class="comment">// inputOptions can be an object or Promise</span>
-<span class="func">var</span> inputOptions = <span class="tag">new</span> <span class="func">Promise</span>(<span class="func"><i>function</i></span> (resolve) {
-  setTimeout(<span class="func"><i>function</i></span> () {
+<span class="func">var</span> inputOptions = <span class="tag">new</span> <span class="func">Promise</span>((resolve) => {
+  setTimeout(() => {
     resolve({
       <span class="str">'#ff0000'</span>: <span class="str">'Red'</span>,
       <span class="str">'#00ff00'</span>: <span class="str">'Green'</span>,
@@ -981,7 +981,7 @@ swal.queue([{
   title: <span class="str">'Select color'</span>,
   input: <span class="str">'radio'</span>,
   inputOptions: inputOptions,
-  inputValidator: <span class="func"><i>function</i></span> (value) {
+  inputValidator: (value) => {
     <span class="tag">return</span> !value && <span class="str">'You need to choose something!'</span>
   }
 })
@@ -1005,7 +1005,7 @@ swal.queue([{
     <span class="str">'I agree with the terms and conditions'</span>,
   confirmButtonText:
     <span class="str">'Continue &lt;i class="fa fa-arrow-right&gt;&lt;/i&gt;'</span>,
-  inputValidator: <span class="func"><i>function</i></span> (result) {
+  inputValidator: (result) => {
     <span class="tag">return</span> !result && <span class="str">'You need to agree with T&amp;C'</span>
   }
 })
@@ -1033,7 +1033,7 @@ swal.queue([{
 
 <span class="tag">if</span> (file) {
   <span class="func">var</span> reader = <span class="tag">new</span> <span class="func">FileReader</span>
-  reader.onload = <span class="func"><i>function</i></span> (e) {
+  reader.onload = (e) => {
     swal({
       title: <span class="str">'Your uploaded picture'</span>,
       imageUrl: e.target.result,
@@ -1081,7 +1081,7 @@ swal({
     <span class="str">'&lt;input id="swal-input1" class="swal2-input"&gt;'</span> +
     <span class="str">'&lt;input id="swal-input2" class="swal2-input"&gt;'</span>,
   focusConfirm: <span class="val">false</span>,
-  preConfirm: <span class="func"><i>function</i></span> () {
+  preConfirm: () => {
     <span class="tag">return</span> [
       $(<span class="str">'#swal-input1'</span>).val(),
       $(<span class="str">'#swal-input2'</span>).val()
@@ -1309,23 +1309,23 @@ swal({
 
 <script>
   /* global $, swal, FileReader */
-  $('.download').on('click', function () {
+  $('.download').on('click', () => {
     $('html, body').animate({scrollTop: $('.download-section').offset().top}, 1000)
   })
 
-  $('.donate').on('click', function () {
+  $('.donate').on('click', () => {
     $('html, body').animate({scrollTop: $('.donations-section').offset().top}, 1000)
   })
 
-  $('.showcase.normal button').on('click', function () {
+  $('.showcase.normal button').on('click', () => {
     window.alert('You clicked the button!')
   })
 
-  $('.showcase.sweet button').on('click', function () {
+  $('.showcase.sweet button').on('click', () => {
     swal('Good job!', 'You clicked the button!', 'success')
   })
 
-  $('.paypal').on('click', function () {
+  $('.paypal').on('click', () => {
     swal({
       title: 'How would you like to pay?',
       input: 'select',
@@ -1336,7 +1336,7 @@ swal({
       },
       inputValue: 'eur',
       confirmButtonText: 'Pay with PayPal'
-    }).then(function (result) {
+    }).then((result) => {
       if (result.value) {
         location.assign('https://www.paypal.me/limonte/5' + result.value);
       }
@@ -1345,26 +1345,26 @@ swal({
     return false;
   })
 
-  $('.examples .message button').on('click', function () {
+  $('.examples .message button').on('click', () => {
     swal('Any fool can use a computer')
   })
 
-  $('.examples .timer button').on('click', function () {
+  $('.examples .timer button').on('click', () => {
     swal({
       title: 'Auto close alert!',
       text: 'I will close in 5 seconds.',
       timer: 5000,
-      onOpen: function() {
+      onOpen: () => {
         swal.showLoading()
       }
-    }).then(function (result) {
+    }).then((result) => {
       if (result.dismiss === 'timer') {
         console.log('I was closed by the timer')
       }
     })
   })
 
-  $('.examples .html button').on('click', function () {
+  $('.examples .html button').on('click', () => {
     swal({
       title: '<i>HTML</i> <u>example</u>',
       type: 'info',
@@ -1382,7 +1382,7 @@ swal({
     })
   })
 
-  $('.examples #position button').on('click', function () {
+  $('.examples #position button').on('click', () => {
     swal({
       position: 'top-right',
       type: 'success',
@@ -1392,7 +1392,7 @@ swal({
     })
   })
 
-  $('.examples .html-jquery button').on('click', function () {
+  $('.examples .html-jquery button').on('click', () => {
     swal({
       title: 'jQuery HTML example',
       html: $('<div>').addClass('some-class').text('jQuery is everywhere.'),
@@ -1401,19 +1401,19 @@ swal({
     })
   })
 
-  $('.examples .title-text button').on('click', function () {
+  $('.examples .title-text button').on('click', () => {
     swal('The Internet?', 'That thing is still around?', 'question')
   })
 
-  $('.examples .error button').on('click', function () {
+  $('.examples .error button').on('click', () => {
     swal('Oops...', 'Something went wrong!', 'error')
   })
 
-  $('.examples #long-text button').on('click', function () {
+  $('.examples #long-text button').on('click', () => {
     swal({html: 'Less is more.<br>'.repeat(100)})
   })
 
-  $('.examples .warning.confirm button').on('click', function () {
+  $('.examples .warning.confirm button').on('click', () => {
     swal({
       title: 'Are you sure?',
       text: 'You won\'t be able to revert this!',
@@ -1422,14 +1422,14 @@ swal({
       confirmButtonColor: '#3085d6',
       cancelButtonColor: '#d33',
       confirmButtonText: 'Yes, delete it!'
-    }).then(function (result) {
+    }).then((result) => {
       if (result.value) {
         swal('Deleted!', 'Your file has been deleted!', 'success')
       }
     })
   })
 
-  $('.examples .warning.cancel button').on('click', function () {
+  $('.examples .warning.cancel button').on('click', () => {
     swal({
       title: 'Are you sure?',
       text: 'Buttons below are styled with Bootstrap classes',
@@ -1442,7 +1442,7 @@ swal({
       confirmButtonClass: 'btn btn-success',
       cancelButtonClass: 'btn btn-danger',
       buttonsStyling: false
-    }).then(function (result) {
+    }).then((result) => {
       if (result.value) {
         swal(
           'Deleted!',
@@ -1460,7 +1460,7 @@ swal({
     })
   })
 
-  $('.examples .custom-image button').on('click', function () {
+  $('.examples .custom-image button').on('click', () => {
     swal({
       title: 'Sweet!',
       text: 'Modal with a custom image.',
@@ -1472,7 +1472,7 @@ swal({
     })
   })
 
-  $('.examples .custom-width-padding-background button').on('click', function () {
+  $('.examples .custom-width-padding-background button').on('click', () => {
     swal({
       title: 'Custom width, padding, background.',
       width: 600,
@@ -1481,14 +1481,14 @@ swal({
     })
   })
 
-  $('.input-type-text').on('click', function () {
+  $('.input-type-text').on('click', () => {
     (async function getName() {
       const {value: name} = await swal({
         title: 'What is your name?',
         input: 'text',
         inputPlaceholder: 'Enter your name or nickname',
         showCancelButton: true,
-        inputValidator: function (value) {
+        inputValidator: (value) => {
           return !value && 'You need to write something!'
         }
       });
@@ -1496,7 +1496,7 @@ swal({
     })()
   })
 
-  $('.input-type-email').on('click', function () {
+  $('.input-type-email').on('click', () => {
     (async function getEmail() {
       const {value: email} = await swal({
         title: 'Input email address',
@@ -1507,7 +1507,7 @@ swal({
     })()
   })
 
-  $('.input-type-url').on('click', function () {
+  $('.input-type-url').on('click', () => {
     (async function getUrl() {
       const {value: url} = await swal({
         input: 'url',
@@ -1517,7 +1517,7 @@ swal({
     })()
   })
 
-  $('.input-type-password').on('click', function () {
+  $('.input-type-password').on('click', () => {
     (async function getPassword() {
       const {value: password} = await swal({
         title: 'Enter your password',
@@ -1533,7 +1533,7 @@ swal({
     })()
   })
 
-  $('.input-type-textarea').on('click', function () {
+  $('.input-type-textarea').on('click', () => {
     (async function getMessage() {
       const {value: text} = await swal({
         input: 'textarea',
@@ -1547,7 +1547,7 @@ swal({
     })()
   })
 
-  $('.input-type-select').on('click', function () {
+  $('.input-type-select').on('click', () => {
     (async function getCountry() {
       const {value: country} = await swal({
         title: 'Select Ukraine',
@@ -1559,8 +1559,8 @@ swal({
         },
         inputPlaceholder: 'Select country',
         showCancelButton: true,
-        inputValidator: function (value) {
-          return new Promise(function (resolve) {
+        inputValidator: (value) => {
+          return new Promise((resolve) => {
             if (value === 'UKR') {
               resolve()
             } else {
@@ -1573,10 +1573,10 @@ swal({
     })()
   })
 
-  $('.input-type-radio').on('click', function () {
+  $('.input-type-radio').on('click', () => {
     (async function getColor() {
-      var inputOptionsPromise = new Promise(function (resolve) {
-        setTimeout(function () {
+      var inputOptionsPromise = new Promise((resolve) => {
+        setTimeout(() => {
           resolve({
             '#FF0000': 'Red',
             '#00FF00': 'Green',
@@ -1589,7 +1589,7 @@ swal({
         title: 'Select color',
         input: 'radio',
         inputOptions: inputOptionsPromise,
-        inputValidator: function (value) {
+        inputValidator: (value) => {
           return !value && 'You need to choose something!'
         }
       })
@@ -1598,7 +1598,7 @@ swal({
     })()
   })
 
-  $('.input-type-checkbox').on('click', function () {
+  $('.input-type-checkbox').on('click', () => {
     (async function acceptTerms() {
       const {value: accept} = await swal({
         title: 'Terms and conditions',
@@ -1606,7 +1606,7 @@ swal({
         inputValue: 1,
         inputPlaceholder: 'I agree with the terms and conditions',
         confirmButtonText: 'Continue <i class="fa fa-arrow-right" style="margin-left: 10px"></i>',
-        inputValidator: function (result) {
+        inputValidator: (result) => {
           return !result && 'To continue you need to agree with T&amp;C'
         }
       })
@@ -1615,7 +1615,7 @@ swal({
     })()
   })
 
-  $('.input-type-file').on('click', function () {
+  $('.input-type-file').on('click', () => {
     (async function getColor() {
       const {value: file} = await swal({
         title: 'Select image',
@@ -1627,7 +1627,7 @@ swal({
       })
       if (file) {
         var reader = new FileReader()
-        reader.onload = function (e) {
+        reader.onload = (e) => {
           swal({
             title: 'Your uploaded picture',
             imageUrl: e.target.result,
@@ -1639,7 +1639,7 @@ swal({
     })()
   })
 
-  $('.input-type-range').on('click', function () {
+  $('.input-type-range').on('click', () => {
     swal({
       title: 'How old are you?',
       type: 'question',
@@ -1653,7 +1653,7 @@ swal({
     })
   })
 
-  $('.input-type-multiple').on('click', function () {
+  $('.input-type-multiple').on('click', () => {
     (async function getForm() {
       const {value: formValues} = await swal({
         title: 'Multiple inputs',
@@ -1661,7 +1661,7 @@ swal({
           '<input id="swal-input1" class="swal2-input" placeholder="first input field">' +
           '<input id="swal-input2" class="swal2-input" placeholder="second input field">',
         focusConfirm: false,
-        preConfirm: function () {
+        preConfirm: () => {
           return [
             $('#swal-input1').val(),
             $('#swal-input2').val()
@@ -1672,7 +1672,7 @@ swal({
     })()
   })
 
-  $('.examples .ajax-request button').on('click', function () {
+  $('.examples .ajax-request button').on('click', () => {
     swal({
       title: 'Submit email to run ajax request',
       input: 'email',
@@ -1680,9 +1680,9 @@ swal({
       confirmButtonText: 'Submit',
       width: 600,
       showLoaderOnConfirm: true,
-      preConfirm: function (email) {
-        return new Promise(function (resolve) {
-          setTimeout(function () {
+      preConfirm: (email) => {
+        return new Promise((resolve) => {
+          setTimeout(() => {
             if (email === 'taken@example.com') {
               swal.showValidationError('This email is already taken.')
             }
@@ -1691,7 +1691,7 @@ swal({
         })
       },
       allowOutsideClick: false
-    }).then(function (result) {
+    }).then((result) => {
       if (result.value) {
         swal({
           type: 'success',
@@ -1702,7 +1702,7 @@ swal({
     })
   })
 
-  $('.examples .chaining-modals button').on('click', function () {
+  $('.examples .chaining-modals button').on('click', () => {
     swal.setDefaults({
       input: 'text',
       confirmButtonText: 'Next &rarr;',
@@ -1716,7 +1716,7 @@ swal({
       'Question 3'
     ]
 
-    swal.queue(steps).then(function (result) {
+    swal.queue(steps).then((result) => {
       swal.resetDefaults()
 
       if (result.value) {
@@ -1729,16 +1729,16 @@ swal({
     })
   })
 
-  $('.examples .dynamic-queue button').on('click', function () {
+  $('.examples .dynamic-queue button').on('click', () => {
     swal.queue([
       {
         title: 'Your public IP',
         confirmButtonText: 'Show my public IP',
         text: 'Your public IP will be received via AJAX request',
         showLoaderOnConfirm: true,
-        preConfirm: function () {
-          return new Promise(function (resolve) {
-            $.get('https://api.ipify.org?format=json').then(function(data) {
+        preConfirm: () => {
+          return new Promise((resolve) => {
+            $.get('https://api.ipify.org?format=json').then((data) => {
               swal.insertQueueStep(data.ip)
               resolve()
             })
@@ -1748,7 +1748,7 @@ swal({
     ])
   })
 
-  $('.modal-types button').on('click', function () {
+  $('.modal-types button').on('click', () => {
     var type = $(this).attr('class').slice(5)
     swal(type + '!', '', type)
   })

--- a/qunit/deprecated.js
+++ b/qunit/deprecated.js
@@ -1,12 +1,12 @@
 /* global $, QUnit, swal */
 
-QUnit.test('confirm button /w useRejections: true', function (assert) {
+QUnit.test('confirm button /w useRejections: true', (assert) => {
   const done = assert.async()
 
   swal({
     title: 'Confirm me',
     useRejections: true
-  }).then(function (result) {
+  }).then((result) => {
     assert.equal(result, true)
     done()
   })
@@ -14,32 +14,32 @@ QUnit.test('confirm button /w useRejections: true', function (assert) {
   swal.clickConfirm()
 })
 
-QUnit.test('cancel button /w useRejections: true', function (assert) {
+QUnit.test('cancel button /w useRejections: true', (assert) => {
   const done = assert.async()
 
   swal({
     title: 'Cancel me',
     useRejections: true
   }).then(
-    function () {},
-    function (dismiss) {
+    () => {},
+    (dismiss) => {
       assert.equal(dismiss, 'cancel')
       done()
     }
-  ).catch(swal.noop)
+  )
 
   swal.clickCancel()
 })
 
-QUnit.test('esc key /w useRejections: true', function (assert) {
+QUnit.test('esc key /w useRejections: true', (assert) => {
   const done = assert.async()
 
   swal({
     title: 'Esc me',
     useRejections: true
   }).then(
-    function () {},
-    function (dismiss) {
+    () => {},
+    (dismiss) => {
       assert.equal(dismiss, 'esc')
       done()
     }
@@ -50,15 +50,15 @@ QUnit.test('esc key /w useRejections: true', function (assert) {
   }))
 })
 
-QUnit.test('overlay click /w useRejections: true', function (assert) {
+QUnit.test('overlay click /w useRejections: true', (assert) => {
   const done = assert.async()
 
   swal({
     title: 'Overlay click',
     useRejections: true
   }).then(
-    function () {},
-    function (dismiss) {
+    () => {},
+    (dismiss) => {
       assert.equal(dismiss, 'overlay')
       done()
     }
@@ -67,7 +67,7 @@ QUnit.test('overlay click /w useRejections: true', function (assert) {
   $('.swal2-container').click()
 })
 
-QUnit.test('timer /w useRejections: true', function (assert) {
+QUnit.test('timer /w useRejections: true', (assert) => {
   const done = assert.async()
 
   swal({
@@ -76,15 +76,15 @@ QUnit.test('timer /w useRejections: true', function (assert) {
     animation: false,
     useRejections: true
   }).then(
-    function () {},
-    function (dismiss) {
+    () => {},
+    (dismiss) => {
       assert.equal(dismiss, 'timer')
       done()
     }
   )
 })
 
-QUnit.test('close button /w useRejections: true', function (assert) {
+QUnit.test('close button /w useRejections: true', (assert) => {
   const done = assert.async()
 
   swal({
@@ -92,8 +92,8 @@ QUnit.test('close button /w useRejections: true', function (assert) {
     showCloseButton: true,
     useRejections: true
   }).then(
-    function () {},
-    function (dismiss) {
+    () => {},
+    (dismiss) => {
       assert.equal(dismiss, 'close')
       done()
     }
@@ -104,14 +104,14 @@ QUnit.test('close button /w useRejections: true', function (assert) {
   $closeButton.click()
 })
 
-QUnit.test('input text /w useRejections: true', function (assert) {
+QUnit.test('input text /w useRejections: true', (assert) => {
   const done = assert.async()
 
   const string = 'Live for yourself'
   swal({
     input: 'text',
     useRejections: true
-  }).then(function (result) {
+  }).then((result) => {
     assert.equal(result, string)
     done()
   })
@@ -120,14 +120,14 @@ QUnit.test('input text /w useRejections: true', function (assert) {
   swal.clickConfirm()
 })
 
-QUnit.test('built-in email validation /w useRejections: true', function (assert) {
+QUnit.test('built-in email validation /w useRejections: true', (assert) => {
   const done = assert.async()
 
   var validEmailAddress = 'team+support+a.b@example.com'
   swal({
     input: 'email',
     useRejections: true
-  }).then(function (result) {
+  }).then((result) => {
     assert.equal(result, validEmailAddress)
     done()
   })
@@ -136,7 +136,7 @@ QUnit.test('built-in email validation /w useRejections: true', function (assert)
   swal.clickConfirm()
 })
 
-QUnit.test('input select /w useRejections: true', function (assert) {
+QUnit.test('input select /w useRejections: true', (assert) => {
   const done = assert.async()
 
   const selected = 'dos'
@@ -144,7 +144,7 @@ QUnit.test('input select /w useRejections: true', function (assert) {
     input: 'select',
     inputOptions: {uno: 1, dos: 2},
     useRejections: true
-  }).then(function (result) {
+  }).then((result) => {
     assert.equal(result, selected)
     done()
   })
@@ -153,7 +153,7 @@ QUnit.test('input select /w useRejections: true', function (assert) {
   swal.clickConfirm()
 })
 
-QUnit.test('input checkbox /w useRejections: true', function (assert) {
+QUnit.test('input checkbox /w useRejections: true', (assert) => {
   const done = assert.async()
 
   swal({
@@ -162,7 +162,7 @@ QUnit.test('input checkbox /w useRejections: true', function (assert) {
       name: 'test-checkbox'
     },
     useRejections: true
-  }).then(function (result) {
+  }).then((result) => {
     assert.equal(checkbox.attr('name'), 'test-checkbox')
     assert.equal(result, '1')
     done()
@@ -173,17 +173,17 @@ QUnit.test('input checkbox /w useRejections: true', function (assert) {
   swal.clickConfirm()
 })
 
-QUnit.test('validation error /w expectRejections: true', function (assert) {
+QUnit.test('validation error /w expectRejections: true', (assert) => {
   const done = assert.async()
   const inputValidator = (value) => !value ? Promise.reject('no falsy values') : Promise.resolve()
 
   swal({input: 'text', animation: false, inputValidator, expectRejections: true})
   assert.ok($('.swal2-validationerror').is(':hidden'))
-  setTimeout(function () {
+  setTimeout(() => {
     const initialModalHeight = $('.swal2-modal').outerHeight()
 
     swal.clickConfirm()
-    setTimeout(function () {
+    setTimeout(() => {
       assert.ok($('.swal2-validationerror').is(':visible'))
       assert.equal($('.swal2-validationerror').text(), 'no falsy values')
       assert.ok($('.swal2-input').attr('aria-invalid'))

--- a/qunit/tests.js
+++ b/qunit/tests.js
@@ -1,15 +1,15 @@
 /* global $, QUnit, swal */
 
-QUnit.test('version is correct semver', function (assert) {
+QUnit.test('version is correct semver', (assert) => {
   assert.ok(swal.version.match(/\d+\.\d+\.\d+/))
 })
 
-QUnit.test('modal shows up', function (assert) {
+QUnit.test('modal shows up', (assert) => {
   swal('Hello world!')
   assert.ok(swal.isVisible())
 })
 
-QUnit.test('modal width', function (assert) {
+QUnit.test('modal width', (assert) => {
   swal({text: '400px', width: 300})
   assert.equal($('.swal2-modal')[0].style.width, '300px')
 
@@ -23,7 +23,7 @@ QUnit.test('modal width', function (assert) {
   assert.equal($('.swal2-modal')[0].style.width, '500px')
 })
 
-QUnit.test('window keydown handler', function (assert) {
+QUnit.test('window keydown handler', (assert) => {
   swal('hi')
   assert.ok(window.onkeydown)
   swal.close()
@@ -36,7 +36,7 @@ QUnit.test('window keydown handler', function (assert) {
   assert.equal(window.onkeydown, null)
 })
 
-QUnit.test('getters', function (assert) {
+QUnit.test('getters', (assert) => {
   swal('Title', 'Content')
   assert.equal(swal.getTitle().innerText, 'Title')
   assert.equal(swal.getContent().innerText, 'Content')
@@ -71,7 +71,7 @@ QUnit.test('getters', function (assert) {
   assert.equal(swal.getInput().value, 'two')
 })
 
-QUnit.test('custom buttons classes', function (assert) {
+QUnit.test('custom buttons classes', (assert) => {
   swal({
     text: 'Modal with custom buttons classes',
     confirmButtonClass: 'btn btn-success ',
@@ -89,7 +89,7 @@ QUnit.test('custom buttons classes', function (assert) {
   assert.notOk($('.swal2-cancel').hasClass('btn-warning'))
 })
 
-QUnit.test('content/title is set (html)', function (assert) {
+QUnit.test('content/title is set (html)', (assert) => {
   swal({
     title: '<strong>Strong</strong>, <em>Emphasis</em>',
     html: '<p>Paragraph</p><img /><button></button>'
@@ -99,7 +99,7 @@ QUnit.test('content/title is set (html)', function (assert) {
   assert.equal($('p, img, button', '.swal2-content').length, 3)
 })
 
-QUnit.test('content/title is set (text)', function (assert) {
+QUnit.test('content/title is set (text)', (assert) => {
   swal({
     titleText: '<strong>Strong</strong>, <em>Emphasis</em>',
     text: '<p>Paragraph</p><img /><button></button>'
@@ -111,7 +111,7 @@ QUnit.test('content/title is set (text)', function (assert) {
   assert.equal($('p, img, button', '.swal2-content').length, 0)
 })
 
-QUnit.test('jQuery/js element as html param', function (assert) {
+QUnit.test('jQuery/js element as html param', (assert) => {
   swal({
     html: $('<p>jQuery element</p>')
   })
@@ -125,7 +125,7 @@ QUnit.test('jQuery/js element as html param', function (assert) {
   assert.equal($('.swal2-content').html(), '<p>js element</p>')
 })
 
-QUnit.test('set and reset defaults', function (assert) {
+QUnit.test('set and reset defaults', (assert) => {
   swal.setDefaults({confirmButtonText: 'Next >', showCancelButton: true})
   swal('Modal with changed defaults')
   assert.equal($('.swal2-confirm').text(), 'Next >')
@@ -139,11 +139,11 @@ QUnit.test('set and reset defaults', function (assert) {
   swal.clickCancel()
 })
 
-QUnit.test('input text', function (assert) {
+QUnit.test('input text', (assert) => {
   const done = assert.async()
 
   const string = 'Live for yourself'
-  swal({input: 'text'}).then(function (result) {
+  swal({input: 'text'}).then((result) => {
     assert.equal(result.value, string)
     done()
   })
@@ -152,17 +152,17 @@ QUnit.test('input text', function (assert) {
   swal.clickConfirm()
 })
 
-QUnit.test('validation error', function (assert) {
+QUnit.test('validation error', (assert) => {
   const done = assert.async()
   const inputValidator = (value) => Promise.resolve(!value && 'no falsy values')
 
   swal({input: 'text', animation: false, inputValidator})
   assert.ok($('.swal2-validationerror').is(':hidden'))
-  setTimeout(function () {
+  setTimeout(() => {
     const initialModalHeight = $('.swal2-modal').outerHeight()
 
     swal.clickConfirm()
-    setTimeout(function () {
+    setTimeout(() => {
       assert.ok($('.swal2-validationerror').is(':visible'))
       assert.equal($('.swal2-validationerror').text(), 'no falsy values')
       assert.ok($('.swal2-input').attr('aria-invalid'))
@@ -177,11 +177,11 @@ QUnit.test('validation error', function (assert) {
   }, 60)
 })
 
-QUnit.test('built-in email validation', function (assert) {
+QUnit.test('built-in email validation', (assert) => {
   const done = assert.async()
 
   var validEmailAddress = 'team+support+a.b@example.com'
-  swal({input: 'email'}).then(function (result) {
+  swal({input: 'email'}).then((result) => {
     assert.equal(result.value, validEmailAddress)
     done()
   })
@@ -190,14 +190,14 @@ QUnit.test('built-in email validation', function (assert) {
   swal.clickConfirm()
 })
 
-QUnit.test('input select', function (assert) {
+QUnit.test('input select', (assert) => {
   const done = assert.async()
 
   const selected = 'dos'
   swal({
     input: 'select',
     inputOptions: {uno: 1, dos: 2}
-  }).then(function (result) {
+  }).then((result) => {
     assert.equal(result.value, selected)
     done()
   })
@@ -206,10 +206,10 @@ QUnit.test('input select', function (assert) {
   swal.clickConfirm()
 })
 
-QUnit.test('input checkbox', function (assert) {
+QUnit.test('input checkbox', (assert) => {
   const done = assert.async()
 
-  swal({input: 'checkbox', inputAttributes: {name: 'test-checkbox'}}).then(function (result) {
+  swal({input: 'checkbox', inputAttributes: {name: 'test-checkbox'}}).then((result) => {
     assert.equal(checkbox.attr('name'), 'test-checkbox')
     assert.equal(result.value, '1')
     done()
@@ -220,7 +220,7 @@ QUnit.test('input checkbox', function (assert) {
   swal.clickConfirm()
 })
 
-QUnit.test('input range', function (assert) {
+QUnit.test('input range', (assert) => {
   swal({ input: 'range', inputAttributes: {min: 1, max: 10}, inputValue: 5 })
   const input = $('.swal2-range input')
   assert.equal(input.attr('min'), '1')
@@ -228,14 +228,14 @@ QUnit.test('input range', function (assert) {
   assert.equal(input.val(), '5')
 })
 
-QUnit.test('queue', function (assert) {
+QUnit.test('queue', (assert) => {
   const done = assert.async()
   const steps = ['Step 1', 'Step 2']
 
   assert.equal(swal.getQueueStep(), null)
 
   swal.setDefaults({animation: false})
-  swal.queue(steps).then(function () {
+  swal.queue(steps).then(() => {
     swal('All done!')
   })
 
@@ -243,12 +243,12 @@ QUnit.test('queue', function (assert) {
   assert.equal(swal.getQueueStep(), 0)
   swal.clickConfirm()
 
-  setTimeout(function () {
+  setTimeout(() => {
     assert.equal($('.swal2-modal h2').text(), 'Step 2')
     assert.equal(swal.getQueueStep(), 1)
     swal.clickConfirm()
 
-    setTimeout(function () {
+    setTimeout(() => {
       assert.equal($('.swal2-modal h2').text(), 'All done!')
       assert.equal(swal.getQueueStep(), null)
       swal.clickConfirm()
@@ -262,13 +262,13 @@ QUnit.test('queue', function (assert) {
   })
 })
 
-QUnit.test('dymanic queue', function (assert) {
+QUnit.test('dymanic queue', (assert) => {
   const done = assert.async()
   const steps = [
     {
       title: 'Step 1',
-      preConfirm: function () {
-        return new Promise(function (resolve) {
+      preConfirm: () => {
+        return new Promise((resolve) => {
           // insert to the end by default
           swal.insertQueueStep('Step 3')
           // step to be deleted
@@ -276,8 +276,8 @@ QUnit.test('dymanic queue', function (assert) {
           // insert with positioning
           swal.insertQueueStep({
             title: 'Step 2',
-            preConfirm: function () {
-              return new Promise(function (resolve) {
+            preConfirm: () => {
+              return new Promise((resolve) => {
                 swal.deleteQueueStep(3)
                 resolve()
               })
@@ -290,24 +290,24 @@ QUnit.test('dymanic queue', function (assert) {
   ]
 
   swal.setDefaults({animation: false})
-  swal.queue(steps).then(function () {
+  swal.queue(steps).then(() => {
     swal('All done!')
   })
 
   assert.equal($('.swal2-modal h2').text(), 'Step 1')
   swal.clickConfirm()
 
-  setTimeout(function () {
+  setTimeout(() => {
     assert.equal($('.swal2-modal h2').text(), 'Step 2')
     assert.equal(swal.getQueueStep(), 1)
     swal.clickConfirm()
 
-    setTimeout(function () {
+    setTimeout(() => {
       assert.equal($('.swal2-modal h2').text(), 'Step 3')
       assert.equal(swal.getQueueStep(), 2)
       swal.clickConfirm()
 
-      setTimeout(function () {
+      setTimeout(() => {
         assert.equal($('.swal2-modal h2').text(), 'All done!')
         assert.equal(swal.getQueueStep(), null)
         swal.clickConfirm()
@@ -317,7 +317,7 @@ QUnit.test('dymanic queue', function (assert) {
   })
 })
 
-QUnit.test('showLoading and hideLoading', function (assert) {
+QUnit.test('showLoading and hideLoading', (assert) => {
   swal.showLoading()
   assert.ok($('.swal2-buttonswrapper').hasClass('swal2-loading'))
   assert.ok($('.swal2-cancel').is(':disabled'))
@@ -340,7 +340,7 @@ QUnit.test('showLoading and hideLoading', function (assert) {
   assert.notOk($('.swal2-buttonswrapper').hasClass('swal2-loading'))
 })
 
-QUnit.test('disable/enable buttons', function (assert) {
+QUnit.test('disable/enable buttons', (assert) => {
   swal('test disable/enable buttons')
 
   swal.disableButtons()
@@ -358,7 +358,7 @@ QUnit.test('disable/enable buttons', function (assert) {
   assert.notOk($('.swal2-confirm').is(':disabled'))
 })
 
-QUnit.test('input radio', function (assert) {
+QUnit.test('input radio', (assert) => {
   swal({
     input: 'radio',
     inputOptions: {
@@ -371,7 +371,7 @@ QUnit.test('input radio', function (assert) {
   assert.equal($('.swal2-radio input[type="radio"]').length, 2)
 })
 
-QUnit.test('disable/enable input', function (assert) {
+QUnit.test('disable/enable input', (assert) => {
   swal({
     input: 'text'
   })
@@ -390,16 +390,16 @@ QUnit.test('disable/enable input', function (assert) {
   })
 
   swal.disableInput()
-  $('.swal2-radio radio').each(function (radio) {
+  $('.swal2-radio radio').each((radio) => {
     assert.ok(radio.is(':disabled'))
   })
   swal.enableInput()
-  $('.swal2-radio radio').each(function (radio) {
+  $('.swal2-radio radio').each((radio) => {
     assert.notOk(radio.is(':disabled'))
   })
 })
 
-QUnit.test('default focus', function (assert) {
+QUnit.test('default focus', (assert) => {
   const done = assert.async()
 
   swal('Modal with the Confirm button only')
@@ -415,13 +415,13 @@ QUnit.test('default focus', function (assert) {
     text: 'Modal with an input',
     input: 'text'
   })
-  setTimeout(function () {
+  setTimeout(() => {
     assert.ok(document.activeElement === $('.swal2-input')[0])
     done()
   })
 })
 
-QUnit.test('reversed buttons', function (assert) {
+QUnit.test('reversed buttons', (assert) => {
   swal({
     text: 'Modal with reversed buttons',
     reverseButtons: true
@@ -432,7 +432,7 @@ QUnit.test('reversed buttons', function (assert) {
   assert.ok($('.swal2-cancel').index() - $('.swal2-confirm').index() === 1)
 })
 
-QUnit.test('focusConfirm', function (assert) {
+QUnit.test('focusConfirm', (assert) => {
   swal({
     showCancelButton: true
   })
@@ -447,7 +447,7 @@ QUnit.test('focusConfirm', function (assert) {
   assert.ok(document.activeElement.outerHTML === anchor[0].outerHTML)
 })
 
-QUnit.test('focusCancel', function (assert) {
+QUnit.test('focusCancel', (assert) => {
   swal({
     text: 'Modal with Cancel button focused',
     showCancelButton: true,
@@ -456,7 +456,7 @@ QUnit.test('focusCancel', function (assert) {
   assert.ok(document.activeElement === $('.swal2-cancel')[0])
 })
 
-QUnit.test('image alt text and custom class', function (assert) {
+QUnit.test('image alt text and custom class', (assert) => {
   swal({
     text: 'Custom class is set',
     imageUrl: 'image.png',
@@ -473,7 +473,7 @@ QUnit.test('image alt text and custom class', function (assert) {
   assert.notOk($('.swal2-image').hasClass('image-custom-class'))
 })
 
-QUnit.test('modal vertical offset', function (assert) {
+QUnit.test('modal vertical offset', (assert) => {
   const done = assert.async(1)
   // create a modal with dynamic-height content
   swal({
@@ -486,12 +486,12 @@ QUnit.test('modal vertical offset', function (assert) {
   })
 
   // if we can't load local images, load an external one instead
-  $('.swal2-image').on('error', function () {
+  $('.swal2-image').on('error', () => {
     this.src = 'https://unsplash.it/150/50?random'
   })
 
   // listen for image load
-  $('.swal2-image').on('load', function () {
+  $('.swal2-image').on('load', () => {
     const box = $('.swal2-modal')[0].getBoundingClientRect()
     const delta = box.top - (box.bottom - box.height)
     // allow 1px difference, in case of uneven height
@@ -500,7 +500,7 @@ QUnit.test('modal vertical offset', function (assert) {
   })
 })
 
-QUnit.test('target', function (assert) {
+QUnit.test('target', (assert) => {
   const warn = console.warn // Suppress the warnings
   console.warn = () => true // Suppress the warnings
   swal('Default target')
@@ -525,26 +525,26 @@ QUnit.test('target', function (assert) {
   console.warn = warn // Suppress the warnings
 })
 
-QUnit.test('onOpen', function (assert) {
+QUnit.test('onOpen', (assert) => {
   const done = assert.async()
 
   // create a modal with an onOpen callback
   swal({
     title: 'onOpen test',
-    onOpen: function ($modal) {
+    onOpen: ($modal) => {
       assert.ok($('.swal2-modal').is($modal))
       done()
     }
   })
 })
 
-QUnit.test('onBeforeOpen', function (assert) {
+QUnit.test('onBeforeOpen', (assert) => {
   const done = assert.async()
 
   // create a modal with an onBeforeOpen callback
   swal({
     title: 'onBeforeOpen test',
-    onBeforeOpen: function ($modal) {
+    onBeforeOpen: ($modal) => {
       assert.ok($('.swal2-modal').is($modal))
     }
   })
@@ -553,23 +553,23 @@ QUnit.test('onBeforeOpen', function (assert) {
   const dynamicTitle = 'Set onBeforeOpen title'
   swal({
     title: 'onBeforeOpen test',
-    onBeforeOpen: function ($modal) {
+    onBeforeOpen: ($modal) => {
       $('.swal2-title').html(dynamicTitle)
     },
-    onOpen: function () {
+    onOpen: () => {
       assert.equal($('.swal2-title').html(), dynamicTitle)
       done()
     }
   })
 })
 
-QUnit.test('onClose', function (assert) {
+QUnit.test('onClose', (assert) => {
   const done = assert.async()
 
   // create a modal with an onClose callback
   swal({
     title: 'onClose test',
-    onClose: function (_$modal) {
+    onClose: (_$modal) => {
       assert.ok($modal.is(_$modal))
       done()
     }
@@ -578,36 +578,35 @@ QUnit.test('onClose', function (assert) {
   const $modal = $('.swal2-modal')
   $('.swal2-close').click()
 })
-QUnit.test('esc key', function (assert) {
+QUnit.test('esc key', (assert) => {
   const done = assert.async()
 
   swal({
     title: 'Esc me'
   }).then(
-    function (result) {
+    (result) => {
       assert.deepEqual(result, {dismiss: 'esc'})
       done()
     },
-    function () {
-    }
+    () => {}
   )
 
   $(document).trigger($.Event('keydown', {
     key: 'Escape'
   }))
 })
-QUnit.test('close button', function (assert) {
+QUnit.test('close button', (assert) => {
   const done = assert.async()
 
   swal({
     title: 'Close button test',
     showCloseButton: true
   }).then(
-    function (result) {
+    (result) => {
       assert.deepEqual(result, {dismiss: 'close'})
       done()
     },
-    function () {}
+    () => {}
   )
 
   const $closeButton = $('.swal2-close')
@@ -615,37 +614,37 @@ QUnit.test('close button', function (assert) {
   assert.equal($closeButton.attr('aria-label'), 'Close this dialog')
   $closeButton.click()
 })
-QUnit.test('overlay click', function (assert) {
+QUnit.test('overlay click', (assert) => {
   const done = assert.async()
 
   swal({
     title: 'Overlay click'
   }).then(
-    function (result) {
+    (result) => {
       assert.deepEqual(result, {dismiss: 'overlay'})
       done()
     },
-    function () {}
+    () => {}
   )
 
   $('.swal2-container').click()
 })
-QUnit.test('cancel button', function (assert) {
+QUnit.test('cancel button', (assert) => {
   const done = assert.async()
 
   swal({
     title: 'Cancel me'
   }).then(
-    function (result) {
+    (result) => {
       assert.deepEqual(result, {dismiss: 'cancel'})
       done()
     },
-    function () {}
+    () => {}
   )
 
   swal.clickCancel()
 })
-QUnit.test('timer', function (assert) {
+QUnit.test('timer', (assert) => {
   const done = assert.async()
 
   swal({
@@ -653,14 +652,14 @@ QUnit.test('timer', function (assert) {
     timer: 10,
     animation: false
   }).then(
-    function (result) {
+    (result) => {
       assert.deepEqual(result, {dismiss: 'timer'})
       done()
     },
-    function () {}
+    () => {}
   )
 })
-QUnit.test('confirm button', function (assert) {
+QUnit.test('confirm button', (assert) => {
   const done = assert.async()
   swal({
     input: 'radio',
@@ -668,7 +667,7 @@ QUnit.test('confirm button', function (assert) {
       'one': 'one',
       'two': 'two'
     }
-  }).then(function (result) {
+  }).then((result) => {
     assert.deepEqual(result, {value: 'two'})
     done()
   })
@@ -676,28 +675,28 @@ QUnit.test('confirm button', function (assert) {
   swal.clickConfirm()
 })
 
-QUnit.test('on errors in *async* user-defined functions, cleans up and propagates the error', function (assert) {
+QUnit.test('on errors in *async* user-defined functions, cleans up and propagates the error', (assert) => {
   const done = assert.async()
 
   const expectedError = new Error('my bad')
-  const erroringFunction = function () {
+  const erroringFunction = () => {
     return Promise.reject(expectedError)
   }
 
   // inputValidator
   const rejectedPromise = swal({input: 'text', expectRejections: false, inputValidator: erroringFunction})
   swal.clickConfirm()
-  rejectedPromise.catch(function (error) {
+  rejectedPromise.catch((error) => {
     assert.equal(error, expectedError) // error is bubbled up back to user code
-    setTimeout(function () {
+    setTimeout(() => {
       assert.notOk(swal.isVisible()) // display is cleaned up
 
       // preConfirm
       const rejectedPromise = swal({expectRejections: false, preConfirm: erroringFunction})
       swal.clickConfirm()
-      rejectedPromise.catch(function (error) {
+      rejectedPromise.catch((error) => {
         assert.equal(error, expectedError) // error is bubbled up back to user code
-        setTimeout(function () {
+        setTimeout(() => {
           assert.notOk(swal.isVisible()) // display is cleaned up
 
           done()
@@ -707,12 +706,12 @@ QUnit.test('on errors in *async* user-defined functions, cleans up and propagate
   })
 })
 
-QUnit.test('params validation', function (assert) {
+QUnit.test('params validation', (assert) => {
   assert.ok(swal.isValidParameter('title'))
   assert.notOk(swal.isValidParameter('foobar'))
 })
 
-QUnit.test('addition and removal of backdrop', function (assert) {
+QUnit.test('addition and removal of backdrop', (assert) => {
   swal({backdrop: false})
   assert.ok(document.body.classList.contains('swal2-no-backdrop'))
   swal({title: 'test'})

--- a/qunit/toast.js
+++ b/qunit/toast.js
@@ -1,15 +1,15 @@
 /* global QUnit, swal */
 
-QUnit.test('.swal2-toast-shown', function (assert) {
+QUnit.test('.swal2-toast-shown', (assert) => {
   swal({toast: true})
   assert.ok(document.body.classList.contains('swal2-toast-shown'))
   swal({toast: false})
   assert.notOk(document.body.classList.contains('swal2-toast-shown'))
 })
 
-QUnit.test('.swal2-has-input', function (assert) {
+QUnit.test('.swal2-has-input', (assert) => {
   var inputs = ['text', 'email', 'password', 'number', 'tel', 'range', 'textarea', 'select', 'radio', 'checkbox', 'file', 'url']
-  inputs.forEach(input => {
+  inputs.forEach((input) => {
     swal({input: input})
     assert.ok(document.body.classList.contains('swal2-has-input'), input)
   })

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -352,7 +352,7 @@ const openPopup = (animation, onBeforeOpen, onComplete) => {
   }
   dom.states.previousActiveElement = document.activeElement
   if (onComplete !== null && typeof onComplete === 'function') {
-    setTimeout(function () {
+    setTimeout(() => {
       onComplete(popup)
     })
   }
@@ -474,7 +474,7 @@ const sweetAlert = (...args) => {
         resolve({dismiss})
       }
     }
-    const errorWith = error => {
+    const errorWith = (error) => {
       sweetAlert.closePopup(params.onClose)
       reject(error)
     }
@@ -1129,7 +1129,7 @@ sweetAlert.queue = (steps) => {
       if (i < queue.length) {
         document.body.setAttribute('data-swal2-queue-step', i)
 
-        sweetAlert(queue[i]).then(result => {
+        sweetAlert(queue[i]).then((result) => {
           if (result.value !== undefined) {
             queueResult.push(result.value)
             step(i + 1, callback)
@@ -1218,7 +1218,7 @@ sweetAlert.close = sweetAlert.closePopup = sweetAlert.closeModal = sweetAlert.cl
     removePopupAndResetState()
   }
   if (onComplete !== null && typeof onComplete === 'function') {
-    setTimeout(function () {
+    setTimeout(() => {
       onComplete(popup)
     })
   }

--- a/test/puppeteer/visual-tests.js
+++ b/test/puppeteer/visual-tests.js
@@ -166,7 +166,7 @@ async function run (testCase) {
   if (argv.update) {
     console.log(clc.green('✓') + ` ${testCase}`)
   } else {
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       looksSame(`${path}${screenName}.png`, `${path}${screenName}-test.png`, (error, equal) => {
         error && console.log(error)
         console.log(


### PR DESCRIPTION
Fixes #743 

https://github.com/limonte/sweetalert2/issues/711#issuecomment-344089223 

> The web used to be a poor platform and we've got used to restrict ourselves from using new feature to support outdated browsers because that was a common things back in the days.
> 
> In fact, we've already seen, in Swal2 issues, people that were struggling with this in callbacks of then(), preConfirm, etc, because they copy-pasted function() { examples from the docs. We told them to use () => { and so far, nobody came back to say "but hey, I'm gettin a syntax error with your strange syntax".