### PR TITLE
Add aria-live: assertive for modals, polite for toasts

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -42,6 +42,9 @@ export const init = (params) => {
   const checkbox = popup.querySelector(`.${swalClasses.checkbox} input`)
   const textarea = getChildByClass(popup, swalClasses.textarea)
 
+  // a11y
+  popup.setAttribute('aria-live', params.toast ? 'polite' : 'assertive')
+
   const resetValidationError = () => {
     sweetAlert.isVisible() && sweetAlert.resetValidationError()
   }


### PR DESCRIPTION
TLDR:
 - modal dialogs are important, announced them asap
 - toasts aren't so important, announce them in the order queue

---

According to the [WAI-ARIA spec](http://www.w3.org/TR/wai-aria/states_and_properties#aria-live):

> The values of this attribute are expressed in degrees of importance. When regions are specified as polite, assistive technologies will notify users of updates but generally do not interrupt the current task, and updates take low priority. When regions are specified as assertive, assistive technologies will immediately notify the user, and could potentially clear the speech queue of previous updates.


Usage notes from the [WAI-ARIA authoring guide](http://www.w3.org/WAI/PF/aria-practices/#liveprops):

> `aria-live="polite"`
Any updates made to this region should only be announced if the user is not currently doing anything. live="polite" should be used in most situations involving live regions that present new information to users, such as updating news headlines. -

> `aria-live="assertive"`
Any updates made to this region are important enough to be announced to the user as soon as possible, but it is not necessary to immediately interrupt the user. live="assertive" must be used if there is information that a user must know about right away, for example, warning messages in a form that does validation on the fly.