### PR TITLE
Fix dismiss on outside click

### DIFF
--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -694,7 +694,24 @@ const sweetAlert = (...args) => {
         }
       }
     } else {
+      // We should igonore clicks that had mousedown on the popup but
+      // mouseup on the container, this can happen when the user drags a slider
+      let ignoreOutsideClick = false
+
+      popup.onmousedown = (e) => {
+        container.onmouseup = function (e) {
+          container.onmouseup = undefined
+          if (e.target === container) {
+            ignoreOutsideClick = true
+          }
+        }
+      }
+
       container.onclick = (e) => {
+        if (ignoreOutsideClick) {
+          ignoreOutsideClick = false
+          return
+        }
         if (e.target !== container) {
           return
         }

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -694,7 +694,7 @@ const sweetAlert = (...args) => {
         }
       }
     } else {
-      // We should igonore clicks that had mousedown on the popup but
+      // We should ignore clicks that had mousedown on the popup but
       // mouseup on the container, this can happen when the user drags a slider
       let ignoreOutsideClick = false
 

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -694,14 +694,27 @@ const sweetAlert = (...args) => {
         }
       }
     } else {
-      // We should ignore clicks that had mousedown on the popup but
-      // mouseup on the container, this can happen when the user drags a slider
       let ignoreOutsideClick = false
 
-      popup.onmousedown = (e) => {
+      // Ignore click events that had mousedown on the popup but mouseup on the container
+      // This can happen when the user drags a slider
+      popup.onmousedown = () => {
         container.onmouseup = function (e) {
           container.onmouseup = undefined
+          // We only check if the mouseup target is the container because usually it doesn't
+          // have any other direct children aside of the popup
           if (e.target === container) {
+            ignoreOutsideClick = true
+          }
+        }
+      }
+
+      // Ignore click events that had mousedown on the container but mouseup on the popup
+      container.onmousedown = () => {
+        popup.onmouseup = function (e) {
+          popup.onmouseup = undefined
+          // We also need to check if the mouseup target is a child of the popup
+          if (e.target === popup || popup.contains(e.target)) {
             ignoreOutsideClick = true
           }
         }


### PR DESCRIPTION
Fix dismiss on outside click by ignoring clicks that had mousedown on the popup but mouseup on the container, this can happen when the user drags a slider.

This fix is inspired by bootstrap:
https://github.com/twbs/bootstrap/blob/6f1e746d70649e17956b0db03f5cd127e5012fab/js/src/modal.js#L352
