### PR TITLE
feature(allowOutsideClick): boolean | () => boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Configuration
 | `customClass`            | `null`                | A custom CSS class for the modal. |
 | `timer`                  | `null`                | Auto close timer of the modal. Set in ms (milliseconds). |
 | `animation`              | `true`                | If set to `false`, modal CSS animation will be disabled. |
-| `allowOutsideClick`      | `true`                | If set to `false`, the user can't dismiss the modal by clicking outside it. |
+| `allowOutsideClick`      | `true`                | If set to `false`, the user can't dismiss the modal by clicking outside it. You can also pass a custom function returning a boolean value, e.g. if you want to disable outside clicks for the loading state of a modal. |
 | `allowEscapeKey`         | `true`                | If set to `false`, the user can't dismiss the modal by pressing the <kbd>Esc</kbd> key. |
 | `allowEnterKey`          | `true`                | If set to `false`, the user can't confirm the modal by pressing the <kbd>Enter</kbd> or <kbd>Space</kbd> keys, unless they manually focus the confirm button. |
 | `showConfirmButton`      | `true`                | If set to `false`, a "Confirm"-button will not be shown. It can be useful when you're using `html` parameter for custom HTML description. |
@@ -236,8 +236,9 @@ Methods
 | `swal.disableButtons()`                         | Disable "Confirm" and "Cancel" buttons. |
 | `swal.enableConfirmButton()`                    | Enable the "Confirm"-button only. |
 | `swal.disableConfirmButton()`                   | Disable the "Confirm"-button only. |
-| `swal.enableLoading()` or `swal.showLoading()`  | Disable buttons and show loader. This is useful with AJAX requests. |
-| `swal.disableLoading()` or `swal.hideLoading()` | Enable buttons and hide loader. |
+| `swal.showLoading()` or `swal.enableLoading()`  | Disable buttons and show loader. This is useful with AJAX requests. |
+| `swal.hideLoading()` or `swal.disableLoading()` | Enable buttons and hide loader. |
+| `swal.isLoading()`                              | Determine if modal is in the loading state. Related methods: `swal.showLoading()` and `swal.hideLoading()`. |
 | `swal.clickConfirm()`                           | Click the "Confirm"-button programmatically. |
 | `swal.clickCancel()`                            | Click the "Cancel"-button programmatically. |
 | `swal.showValidationError(error)`               | Show validation error message. |

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@ swal({
       }, <span class="val">2000</span>)
     })
   },
-  allowOutsideClick: <span class="val">false</span>
+  allowOutsideClick: () => swal.isLoading()
 }).<span class="tag">then</span>((result) => {
   <span class="tag">if</span> (result.value) {
     swal({
@@ -558,7 +558,7 @@ swal.queue([{
       <tr id="allow-outside-click">
         <td><b>allowOutsideClick</b></td>
         <td><i>true</i></td>
-        <td>If set to <strong>false</strong>, the user can't dismiss the modal by clicking outside it.</td>
+        <td>If set to <strong>false</strong>, the user can't dismiss the modal by clicking outside it.<br>You can also pass a custom function returning a boolean value, e.g. if you want to disable outside clicks for the loading state of a modal.</td>
       </tr>
       <tr id="allow-escape-key">
         <td><b>allowEscapeKey</b></td>
@@ -1183,13 +1183,17 @@ swal({
         <td><i>swal.disableConfirmButton()</i></td>
         <td>Disable the "Confirm"-button only.</td>
       </tr>
-      <tr>
+      <tr id="showLoading">
         <td><i>swal.showLoading()</i> or <i>swal.enableLoading()</i></td>
         <td>Disable buttons and show loader. This is useful with AJAX requests.</td>
       </tr>
-      <tr>
+      <tr id="hideLoading">
         <td><i>swal.hideLoading()</i> or <i>swal.disableLoading()</i></td>
         <td>Enable buttons and hide loader.</td>
+      </tr>
+      <tr>
+        <td><i>swal.isLoading()</i></td>
+        <td>Determine if modal is in the loading state. Related methods: <a href="#showLoading">swal.showLoading()</a> and  <a href="#hideLoading">swal.hideLoading()</a></td>
       </tr>
       <tr>
         <td><i>swal.clickConfirm()</i></td>
@@ -1718,7 +1722,7 @@ swal({
           }, 2000)
         })
       },
-      allowOutsideClick: false
+      allowOutsideClick: () => !swal.isLoading()
     }).then((result) => {
       if (result.value) {
         swal({

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -725,7 +725,13 @@ const sweetAlert = (...args) => {
           return
         }
         if (params.allowOutsideClick) {
-          dismissWith('overlay')
+          if (typeof params.allowOutsideClick === 'function') {
+            if (params.allowOutsideClick()) {
+              dismissWith('overlay')
+            }
+          } else {
+            dismissWith('overlay')
+          }
         }
       }
     }
@@ -851,6 +857,7 @@ const sweetAlert = (...args) => {
       }
       dom.removeClass([popup, buttonsWrapper], swalClasses.loading)
       popup.removeAttribute('aria-busy')
+      popup.removeAttribute('data-loading')
       confirmButton.disabled = false
       cancelButton.disabled = false
     }
@@ -862,6 +869,7 @@ const sweetAlert = (...args) => {
     sweetAlert.getButtonsWrapper = () => dom.getButtonsWrapper()
     sweetAlert.getConfirmButton = () => dom.getConfirmButton()
     sweetAlert.getCancelButton = () => dom.getCancelButton()
+    sweetAlert.isLoading = () => dom.isLoading()
 
     sweetAlert.enableButtons = () => {
       confirmButton.disabled = false
@@ -1293,6 +1301,7 @@ sweetAlert.showLoading = sweetAlert.enableLoading = () => {
   confirmButton.disabled = true
   cancelButton.disabled = true
 
+  popup.setAttribute('data-loading', true)
   popup.setAttribute('aria-busy', true)
   popup.focus()
 }

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -181,6 +181,10 @@ export const isToast = () => {
   return document.body.classList.contains(swalClasses['toast-shown'])
 }
 
+export const isLoading = () => {
+  return getPopup().hasAttribute('data-loading')
+}
+
 export const hasClass = (elem, className) => {
   if (elem.classList) {
     return elem.classList.contains(className)
@@ -254,7 +258,7 @@ export const empty = (elem) => {
 }
 
 // borrowed from jquery $(elem).is(':visible') implementation
-export const isVisible = (elem) => elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length
+export const isVisible = (elem) => elem && (elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)
 
 export const removeStyleProperty = (elem, property) => {
   if (elem.style.removeProperty) {

--- a/sweetalert2.d.ts
+++ b/sweetalert2.d.ts
@@ -119,6 +119,11 @@ declare module 'sweetalert2' {
         function hideLoading(): void;
 
         /**
+         * Determine if modal is in the loading state.
+         */
+        function isLoading(): boolean;
+
+        /**
          * Click the "Confirm"-button programmatically.
          */
         function clickConfirm(): void;
@@ -213,6 +218,8 @@ declare module 'sweetalert2' {
         'file' | 'url' | undefined;
 
     export type SweetAlertDismissalReason = 'cancel' | 'close' | 'overlay' | 'esc' | 'timer';
+
+    export type SweetAlertAllowOutsideClick = () => boolean;
 
     export interface SweetAlertInputOptions {
         [inputValue: string]: string;
@@ -356,10 +363,12 @@ declare module 'sweetalert2' {
 
         /**
          * If set to false, the user can't dismiss the modal by clicking outside it.
+         * You can also pass a custom function returning a boolean value, e.g. if you want
+         * to disable outside clicks for the loading state of a modal.
          *
          * @default true
          */
-        allowOutsideClick?: boolean;
+        allowOutsideClick?: boolean | SweetAlertAllowOutsideClick;
 
         /**
          * If set to false, the user can't dismiss the modal by pressing the Escape key.

--- a/test/qunit/index.html
+++ b/test/qunit/index.html
@@ -12,6 +12,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/2.4.1/core.js"></script>
   <script src="../../dist/sweetalert2.js"></script>
 
+  <script src="./outside-click.js"></script>
   <script src="./deprecated.js"></script>
   <script src="./toast.js"></script>
   <script src="./tests.js"></script>

--- a/test/qunit/outside-click.js
+++ b/test/qunit/outside-click.js
@@ -1,0 +1,91 @@
+/* global $, QUnit, swal */
+
+const simulateMouseEvent = (x, y, eventType) => {
+  var event = $.Event(eventType)
+  event.clientX = x
+  event.clientY = y
+  $(document.elementFromPoint(x, y)).trigger(event)
+}
+
+QUnit.test('overlay click', (assert) => {
+  const done = assert.async()
+
+  swal({
+    title: 'Overlay click'
+  }).then((result) => {
+    assert.deepEqual(result, {dismiss: 'overlay'})
+    done()
+  })
+
+  $('.swal2-container').click()
+})
+
+QUnit.test('popup mousedown, overlay mouseup', (assert) => {
+  const done = assert.async()
+
+  swal({
+    title: 'popup mousedown, overlay mouseup'
+  })
+
+  simulateMouseEvent(1, 1, 'mousedown')
+  simulateMouseEvent(window.innerWidth / 2, window.innerHeight / 2, 'mouseup')
+
+  setTimeout(() => {
+    assert.ok(swal.isVisible())
+    done()
+  }, 300)
+})
+
+QUnit.test('overlay mousedown, popup mouseup', (assert) => {
+  const done = assert.async()
+
+  swal({
+    title: 'overlay mousedown, popup mouseup'
+  })
+
+  simulateMouseEvent(window.innerWidth / 2, window.innerHeight / 2, 'mousedown')
+  simulateMouseEvent(1, 1, 'mouseup')
+
+  setTimeout(() => {
+    assert.ok(swal.isVisible())
+    done()
+  }, 300)
+})
+
+QUnit.test('allowOutsideClick: false', (assert) => {
+  const done = assert.async()
+
+  swal({
+    title: 'allowOutsideClick: false',
+    allowOutsideClick: false
+  })
+
+  $('.swal2-container').click()
+
+  setTimeout(() => {
+    assert.ok(swal.isVisible())
+    done()
+  }, 300)
+})
+
+QUnit.test('allowOutsideClick: () => !swal.isLoading()', (assert) => {
+  const done = assert.async()
+
+  swal({
+    title: 'allowOutsideClick: () => !swal.isLoading()',
+    allowOutsideClick: () => !swal.isLoading()
+  }).then((result) => {
+    assert.deepEqual(result, {dismiss: 'overlay'})
+    done()
+  })
+
+  swal.showLoading()
+
+  $('.swal2-container').click()
+
+  setTimeout(() => {
+    assert.ok(swal.isVisible())
+    swal.hideLoading()
+    $('.swal2-container').click()
+  }, 300)
+})

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -1,12 +1,5 @@
 /* global $, QUnit, swal */
 
-const simulateMouseEvent = (x, y, eventType) => {
-  var event = $.Event(eventType)
-  event.clientX = x
-  event.clientY = y
-  $(document.elementFromPoint(x, y)).trigger(event)
-}
-
 QUnit.test('version is correct semver', (assert) => {
   assert.ok(swal.version.match(/\d+\.\d+\.\d+/))
 })
@@ -590,13 +583,10 @@ QUnit.test('esc key', (assert) => {
 
   swal({
     title: 'Esc me'
-  }).then(
-    (result) => {
-      assert.deepEqual(result, {dismiss: 'esc'})
-      done()
-    },
-    () => {}
-  )
+  }).then((result) => {
+    assert.deepEqual(result, {dismiss: 'esc'})
+    done()
+  })
 
   $(document).trigger($.Event('keydown', {
     key: 'Escape'
@@ -608,76 +598,25 @@ QUnit.test('close button', (assert) => {
   swal({
     title: 'Close button test',
     showCloseButton: true
-  }).then(
-    (result) => {
-      assert.deepEqual(result, {dismiss: 'close'})
-      done()
-    },
-    () => {}
-  )
+  }).then((result) => {
+    assert.deepEqual(result, {dismiss: 'close'})
+    done()
+  })
 
   const $closeButton = $('.swal2-close')
   assert.ok($closeButton.is(':visible'))
   assert.equal($closeButton.attr('aria-label'), 'Close this dialog')
   $closeButton.click()
 })
-QUnit.test('overlay click', (assert) => {
-  const done = assert.async()
-
-  swal({
-    title: 'Overlay click'
-  }).then(
-    (result) => {
-      assert.deepEqual(result, {dismiss: 'overlay'})
-      done()
-    },
-    () => {}
-  )
-
-  $('.swal2-container').click()
-})
-QUnit.test('popup mousedown, overlay mouseup', (assert) => {
-  const done = assert.async()
-
-  swal({
-    title: 'popup mousedown, overlay mouseup'
-  })
-
-  simulateMouseEvent(1, 1, 'mousedown')
-  simulateMouseEvent(window.innerWidth / 2, window.innerHeight / 2, 'mouseup')
-
-  setTimeout(() => {
-    assert.ok(swal.isVisible())
-    done()
-  }, 300)
-})
-QUnit.test('overlay mousedown, popup mouseup', (assert) => {
-  const done = assert.async()
-
-  swal({
-    title: 'overlay mousedown, popup mouseup'
-  })
-
-  simulateMouseEvent(window.innerWidth / 2, window.innerHeight / 2, 'mousedown')
-  simulateMouseEvent(1, 1, 'mouseup')
-
-  setTimeout(() => {
-    assert.ok(swal.isVisible())
-    done()
-  }, 300)
-})
 QUnit.test('cancel button', (assert) => {
   const done = assert.async()
 
   swal({
     title: 'Cancel me'
-  }).then(
-    (result) => {
-      assert.deepEqual(result, {dismiss: 'cancel'})
-      done()
-    },
-    () => {}
-  )
+  }).then((result) => {
+    assert.deepEqual(result, {dismiss: 'cancel'})
+    done()
+  })
 
   swal.clickCancel()
 })
@@ -688,13 +627,10 @@ QUnit.test('timer', (assert) => {
     title: 'Timer test',
     timer: 10,
     animation: false
-  }).then(
-    (result) => {
-      assert.deepEqual(result, {dismiss: 'timer'})
-      done()
-    },
-    () => {}
-  )
+  }).then((result) => {
+    assert.deepEqual(result, {dismiss: 'timer'})
+    done()
+  })
 })
 QUnit.test('confirm button', (assert) => {
   const done = assert.async()


### PR DESCRIPTION
Fixes #782 

1. Add the `swal.isLoading()` getter

2. `allowOutsideClick` now can accept a function, e.g.
 
```js
swal({
  ...
  allowOutsideClick: () => swal.isLoading()
})
```