### PR TITLE
feature(frameworks-integration): add React element support for the html parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,11 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 
+  <!-- React integration -->
+  <script src="https://unpkg.com/babel-core@5.8.33/browser.js"></script>
+  <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+
   <link rel="preload" href="https://unsplash.it/400/200/?random" as="image">
   <link rel="preload" href="https://bit.ly/1Nqn9HU" as="image">
 
@@ -404,6 +409,24 @@ swal.queue([{
     })
   }
 }])</pre>
+    </li>
+  </ul>
+
+  <!-- Download & Install -->
+  <div class="center-container download-section">
+    <h3>Integration with frameworks</h3>
+  </div>
+
+  <ul class="examples">
+    <li class="react-integration" id="react-integration">
+      <div class="ui">
+        <p>Just pass JSX to the html parameter</p>
+        <button aria-label="Try me! Example: Dynamic queue">Try me!</button>
+      </div>
+      <pre>
+swal({
+  html: <span class="val">&lt;div></span>Hello, React!<span class="val">&lt;/div></span>,
+})</pre>
     </li>
   </ul>
 
@@ -1793,6 +1816,15 @@ swal({
     ga('send', 'pageview')
   }
 </script>
+
+<script type="text/babel">
+  $('.examples .react-integration button').on('click', () => {
+    swal({
+      html: <div>Hello, React!</div>
+    })
+  })
+</script>
+
 <script src="./assets/example.js"></script>
 <div id="rtl-container" dir="rtl"></div>
 </body>

--- a/src/sweetalert2.js
+++ b/src/sweetalert2.js
@@ -1,3 +1,5 @@
+/* globals React, ReactDOM */
+
 import defaultParams, { deprecatedParams } from './utils/params.js'
 import { swalClasses, iconTypes } from './utils/classes.js'
 import { colorLuminance, warn, error, warnOnce } from './utils/utils.js'
@@ -88,7 +90,11 @@ const setParameters = (params) => {
 
   // Content
   if (params.text || params.html) {
-    if (typeof params.html === 'object') {
+    if (typeof React !== 'undefined' && typeof ReactDOM !== 'undefined') {
+      if (React.isValidElement(params.html)) {
+        ReactDOM.render(params.html, dom.getContent())
+      }
+    } else if (typeof params.html === 'object') {
       content.innerHTML = ''
       if (0 in params.html) {
         for (let i = 0; i in params.html; i++) {
@@ -1234,6 +1240,10 @@ sweetAlert.close = sweetAlert.closePopup = sweetAlert.closeModal = sweetAlert.cl
   }
 
   const removePopupAndResetState = () => {
+    if (typeof ReactDOM !== 'undefined') {
+      ReactDOM.unmountComponentAtNode(dom.getContent())
+    }
+
     if (container.parentNode) {
       container.parentNode.removeChild(container)
     }


### PR DESCRIPTION
Fixes #637

I would like to suppot a huge and fast-growing React community by providing React Elements support out-of-the-box.

Before:

```js
swal({
  onOpen: () => ReactDOM.render(
    <div>Hello, React</div>,
    swal.getContent()
  ),
  onClose: () => ReactDOM.unmountComponentAtNode(swal.getContent())
})
```

After:

```js
swal({
  html: <div>Hello, React</div>
})
```

I would like to hear all your opinions guys, especially @toverux @acupajoe @zenflow @samturrell @birjolaxew @FinesseRus

Would it be useful? Is it worthy? If so, should we support Vue.js components as well? (#790) Any thoughts would be so welcome, thanks in advance!
  